### PR TITLE
Add native HEIF and AVIF image loading via FFmpeg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,31 @@ if(NOT IDIFF_HAVE_FFMPEG)
         "video container files (MP4, MKV, etc.) will not be supported")
 endif()
 
+# HEIF / AVIF decoder selection.
+#
+# FFmpeg ≥ 8.0 ships HEVC + AV1 decoders and the ISOBMFF demuxer that
+# parses HEIF / AVIF tile-grid metadata; combined with libavfilter
+# (already linked when IDIFF_HAVE_FFMPEG is ON) idiff can natively
+# read .heic / .heif / .hif / .avif without pulling in libheif /
+# libavif / libde265 / dav1d as direct dependencies.  ImageMagick is
+# kept as a fallback for builds without FFmpeg, since it can also
+# read those formats when its libheif delegate is present.
+set(IDIFF_HAVE_FFMPEG_IMAGE_DECODE OFF)
+if(IDIFF_HAVE_FFMPEG)
+    set(IDIFF_HAVE_FFMPEG_IMAGE_DECODE ON)
+endif()
+
+if(IDIFF_HAVE_FFMPEG_IMAGE_DECODE)
+    message(STATUS "HEIF / AVIF backend: FFmpeg (preferred), "
+                   "ImageMagick (fallback if available)")
+elseif(IDIFF_HAVE_IMAGEMAGICK)
+    message(STATUS "HEIF / AVIF backend: ImageMagick "
+                   "(install FFmpeg ≥ 8.0 for native support)")
+else()
+    message(STATUS "HEIF / AVIF backend: NONE -- .heic / .avif files "
+                   "cannot be opened in this build")
+endif()
+
 # SDL2
 find_package(SDL2 REQUIRED CONFIG)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ choose **Mark as Reference** to promote it to the top of the list.
 
 ### Image Support
 
-- **Formats**: PNG, JPEG, WebP, TIFF, BMP, RAW (via LibRaw, optional), HEIF/AVIF (via ImageMagick, optional)
+- **Formats**: PNG, JPEG, WebP, TIFF, BMP, RAW (via LibRaw, optional), HEIF/AVIF (via FFmpeg ≥ 8.0, or ImageMagick 7+ as fallback)
 - **ICC color profile** detection and display
 - **Raw YUV video streams** — configurable resolution, pixel format, frame stepping
 - **HTTP/HTTPS URLs** — automatic download with on-disk cache and background prefetch

--- a/src/app/properties_panel.cpp
+++ b/src/app/properties_panel.cpp
@@ -100,6 +100,8 @@ void PropertiesPanel::render_image_props(const char* slot_label, const char* nam
                 case SourceFormat::TIFF:   fmt_name = "TIFF"; break;
                 case SourceFormat::BMP:    fmt_name = "BMP"; break;
                 case SourceFormat::RAW:    fmt_name = "RAW"; break;
+                case SourceFormat::HEIF:   fmt_name = "HEIF"; break;
+                case SourceFormat::AVIF:   fmt_name = "AVIF"; break;
                 default: break;
             }
 

--- a/src/app/ui/toolbar.cpp
+++ b/src/app/ui/toolbar.cpp
@@ -41,11 +41,21 @@ void render_toolbar(const ToolbarInputs& in) {
         ImGui::MenuItem("Inspector", nullptr, in.show_inspector);
 
         if (ImGui::BeginMenu("Image Loader")) {
-            // Let the user compare decoding output between backends at
-            // runtime.  Switching reloads all currently-open images so
-            // the viewport immediately reflects the new backend.  A
-            // backend entry is disabled (and annotated) when it was
-            // not compiled into this build.
+            // The selectable items below set the *preferred backend
+            // for general still images* (PNG / JPEG / WebP / TIFF /
+            // BMP).  HEIF / AVIF is not user-selectable: those
+            // formats always try FFmpeg first, then fall back to
+            // ImageMagick, then OpenCV, regardless of the choice
+            // here -- FFmpeg cannot decode the general formats and
+            // OpenCV cannot decode HEIF/AVIF, so a single global
+            // toggle would be wrong for one half of the file types.
+            //
+            // The FFmpeg row below is therefore informational only:
+            // it shows whether the FFmpeg image backend is built in,
+            // not a user choice.
+            ImGui::TextDisabled("Preferred backend (PNG / JPEG / etc.)");
+            ImGui::Separator();
+
             auto loader_item = [&](LoaderBackend b) {
                 const bool available = ImageLoader::has_backend(b);
                 const bool selected = in.get_loader_backend &&
@@ -60,6 +70,25 @@ void render_toolbar(const ToolbarInputs& in) {
             };
             loader_item(LoaderBackend::ImageMagick);
             loader_item(LoaderBackend::OpenCV);
+
+            ImGui::Separator();
+            ImGui::TextDisabled("HEIF / AVIF (automatic)");
+            {
+                const bool ffmpeg_available =
+                    ImageLoader::has_backend(LoaderBackend::FFmpeg);
+                std::string ff_label = "FFmpeg  (preferred for HEIF / AVIF)";
+                if (!ffmpeg_available) ff_label += "  (not compiled in)";
+                // Disabled: this is a status row, not a chooser.
+                ImGui::MenuItem(ff_label.c_str(), nullptr,
+                                /*selected*/ ffmpeg_available,
+                                /*enabled*/  false);
+            }
+            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+                ImGui::SetTooltip(
+                    "HEIF / AVIF files always try FFmpeg first, then\n"
+                    "ImageMagick, then OpenCV. The selection above\n"
+                    "only affects general formats like PNG and JPEG.");
+            }
             ImGui::EndMenu();
         }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -44,6 +44,13 @@ if(IDIFF_HAVE_FFMPEG)
         video_filter_graph.cpp
     )
     target_compile_definitions(idiff_core PUBLIC IDIFF_HAVE_FFMPEG)
+    if(IDIFF_HAVE_FFMPEG_IMAGE_DECODE)
+        target_sources(idiff_core PRIVATE
+            detail/heif_tile_assembler.cpp
+            detail/ffmpeg_image_loader.cpp
+        )
+        target_compile_definitions(idiff_core PUBLIC IDIFF_HAVE_FFMPEG_IMAGE_DECODE)
+    endif()
     target_link_libraries(idiff_core PUBLIC
         PkgConfig::FFMPEG_LIBAVFORMAT
         PkgConfig::FFMPEG_LIBAVCODEC

--- a/src/core/detail/ffmpeg_image_loader.cpp
+++ b/src/core/detail/ffmpeg_image_loader.cpp
@@ -1,0 +1,616 @@
+// SPDX-License-Identifier: BSD-2-Clause
+#ifdef IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+
+#include "core/detail/ffmpeg_image_loader.h"
+#include "core/detail/heif_tile_assembler.h"
+#include "core/image_impl.h"
+#include "core/image_loader.h"  // for LoadFlag
+#include "util/logger.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/error.h>
+#include <libavutil/frame.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/mem.h>
+#include <libavutil/pixdesc.h>
+#include <libswscale/swscale.h>
+}
+
+#include <opencv2/core.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <new>
+#include <string>
+#include <vector>
+
+namespace idiff {
+
+namespace {
+
+// ============================================================================
+// Misc helpers
+// ============================================================================
+
+void set_av_err(std::string& err, const char* prefix, int ret) {
+    char buf[128];
+    av_strerror(ret, buf, sizeof(buf));
+    err = std::string(prefix) + ": " + buf;
+}
+
+bool has_flag(std::uint32_t flags, LoadFlag flag) {
+    return (flags & static_cast<std::uint32_t>(flag)) != 0;
+}
+
+// ============================================================================
+// In-memory AVIO bridge
+// ============================================================================
+//
+// Lets us hand libavformat a plain `(data, size)` buffer the same way
+// the ImageMagick / OpenCV paths do, avoiding Windows non-ASCII path
+// bugs and matching the decoder-from-memory contract used elsewhere
+// in the codebase.
+
+struct MemReader {
+    const uint8_t* data;
+    std::size_t size;
+    std::size_t pos;
+};
+
+int memreader_read(void* opaque, uint8_t* buf, int buf_size) {
+    auto* r = static_cast<MemReader*>(opaque);
+    if (r->pos >= r->size) return AVERROR_EOF;
+    std::size_t remaining = r->size - r->pos;
+    int n = static_cast<int>(std::min<std::size_t>(remaining,
+                                static_cast<std::size_t>(buf_size)));
+    std::memcpy(buf, r->data + r->pos, n);
+    r->pos += n;
+    return n;
+}
+
+int64_t memreader_seek(void* opaque, int64_t offset, int whence) {
+    auto* r = static_cast<MemReader*>(opaque);
+    if (whence == AVSEEK_SIZE) {
+        return static_cast<int64_t>(r->size);
+    }
+    int64_t target = 0;
+    switch (whence) {
+        case SEEK_SET: target = offset; break;
+        case SEEK_CUR: target = static_cast<int64_t>(r->pos) + offset; break;
+        case SEEK_END: target = static_cast<int64_t>(r->size) + offset; break;
+        default: return -1;
+    }
+    if (target < 0 || target > static_cast<int64_t>(r->size)) {
+        return -1;
+    }
+    r->pos = static_cast<std::size_t>(target);
+    return target;
+}
+
+// ============================================================================
+// RAII wrappers
+// ============================================================================
+
+struct AVIOContextDeleter {
+    void operator()(AVIOContext* ctx) const noexcept {
+        if (!ctx) return;
+        // The reader buffer was allocated via av_malloc(); avio_context_free
+        // does not free the user buffer, only the AVIOContext itself.
+        if (ctx->buffer) av_freep(&ctx->buffer);
+        avio_context_free(&ctx);
+    }
+};
+using AVIOContextPtr = std::unique_ptr<AVIOContext, AVIOContextDeleter>;
+
+struct AVFormatContextDeleter {
+    void operator()(AVFormatContext* ctx) const noexcept {
+        if (ctx) avformat_close_input(&ctx);
+    }
+};
+using AVFormatContextPtr = std::unique_ptr<AVFormatContext, AVFormatContextDeleter>;
+
+struct AVCodecContextDeleter {
+    void operator()(AVCodecContext* ctx) const noexcept {
+        if (ctx) avcodec_free_context(&ctx);
+    }
+};
+using AVCodecContextPtr = std::unique_ptr<AVCodecContext, AVCodecContextDeleter>;
+
+struct AVPacketDeleter {
+    void operator()(AVPacket* p) const noexcept {
+        if (p) av_packet_free(&p);
+    }
+};
+using AVPacketPtr = std::unique_ptr<AVPacket, AVPacketDeleter>;
+
+struct AVFrameDeleter {
+    void operator()(AVFrame* f) const noexcept {
+        if (f) av_frame_free(&f);
+    }
+};
+using AVFramePtr = std::unique_ptr<AVFrame, AVFrameDeleter>;
+
+struct SwsContextDeleter {
+    void operator()(SwsContext* sws) const noexcept {
+        if (sws) sws_freeContext(sws);
+    }
+};
+using SwsContextPtr = std::unique_ptr<SwsContext, SwsContextDeleter>;
+
+// ============================================================================
+// Single-stream decode
+// ============================================================================
+//
+// HEIF / AVIF stream groups expose every tile as its own AVStream.
+// Each tile is a single still picture, so a single decode_packet +
+// flush is enough to pull exactly one AVFrame.
+
+AVFramePtr decode_one_frame(AVFormatContext* fmt_ctx,
+                            int stream_index,
+                            std::string& err) {
+    AVStream* st = fmt_ctx->streams[stream_index];
+    const AVCodec* dec = avcodec_find_decoder(st->codecpar->codec_id);
+    if (!dec) {
+        char buf[96];
+        std::snprintf(buf, sizeof(buf),
+                      "stream %d: no decoder for codec id %d",
+                      stream_index, static_cast<int>(st->codecpar->codec_id));
+        err = buf;
+        return nullptr;
+    }
+
+    AVCodecContextPtr cctx(avcodec_alloc_context3(dec));
+    if (!cctx) {
+        err = "avcodec_alloc_context3 failed";
+        return nullptr;
+    }
+    if (int ret = avcodec_parameters_to_context(cctx.get(), st->codecpar);
+        ret < 0) {
+        set_av_err(err, "avcodec_parameters_to_context failed", ret);
+        return nullptr;
+    }
+    if (int ret = avcodec_open2(cctx.get(), dec, nullptr); ret < 0) {
+        char prefix[64];
+        std::snprintf(prefix, sizeof(prefix),
+                      "stream %d: avcodec_open2 failed", stream_index);
+        set_av_err(err, prefix, ret);
+        return nullptr;
+    }
+
+    AVPacketPtr pkt(av_packet_alloc());
+    AVFramePtr frame(av_frame_alloc());
+    if (!pkt || !frame) {
+        err = "packet/frame alloc failed";
+        return nullptr;
+    }
+
+    // Rewind so we don't miss any earlier tile when called sequentially
+    // for multiple streams in the same fmt_ctx -- demuxer position is
+    // shared across streams.
+    av_seek_frame(fmt_ctx, stream_index, 0, AVSEEK_FLAG_BYTE);
+
+    bool got_frame = false;
+    while (!got_frame) {
+        int ret = av_read_frame(fmt_ctx, pkt.get());
+        if (ret == AVERROR_EOF) {
+            // EOF: send NULL to flush any buffered output.
+            avcodec_send_packet(cctx.get(), nullptr);
+        } else if (ret < 0) {
+            set_av_err(err, "av_read_frame failed", ret);
+            return nullptr;
+        } else if (pkt->stream_index != stream_index) {
+            av_packet_unref(pkt.get());
+            continue;
+        } else {
+            ret = avcodec_send_packet(cctx.get(), pkt.get());
+            av_packet_unref(pkt.get());
+            if (ret < 0) {
+                set_av_err(err, "avcodec_send_packet failed", ret);
+                return nullptr;
+            }
+        }
+
+        ret = avcodec_receive_frame(cctx.get(), frame.get());
+        if (ret == 0) {
+            got_frame = true;
+            break;
+        }
+        if (ret == AVERROR(EAGAIN)) {
+            continue;
+        }
+        if (ret == AVERROR_EOF) {
+            err = "decoder produced no frame";
+            return nullptr;
+        }
+        set_av_err(err, "avcodec_receive_frame failed", ret);
+        return nullptr;
+    }
+
+    return frame;
+}
+
+// ============================================================================
+// AVFrame -> Image (RGB(A) 8 / 16-bit)
+// ============================================================================
+
+PixelFormat select_target_pixel_format(AVPixelFormat src,
+                                       std::uint32_t flags,
+                                       AVPixelFormat& out_av_fmt) {
+    const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(src);
+    bool src_has_alpha = desc && (desc->flags & AV_PIX_FMT_FLAG_ALPHA);
+    bool src_high_depth = false;
+    if (desc && desc->nb_components > 0) {
+        src_high_depth = desc->comp[0].depth > 8;
+    }
+
+    bool keep_alpha = has_flag(flags, LoadFlag::KeepAlpha) && src_has_alpha;
+    bool keep_16    = has_flag(flags, LoadFlag::Keep16Bit) && src_high_depth;
+
+    if (keep_16 && keep_alpha) {
+        out_av_fmt = AV_PIX_FMT_RGBA64LE;
+        return PixelFormat::RGBA16;
+    }
+    if (keep_16) {
+        out_av_fmt = AV_PIX_FMT_RGB48LE;
+        return PixelFormat::RGB16;
+    }
+    if (keep_alpha) {
+        out_av_fmt = AV_PIX_FMT_RGBA;
+        return PixelFormat::RGBA8;
+    }
+    out_av_fmt = AV_PIX_FMT_RGB24;
+    return PixelFormat::RGB8;
+}
+
+int pixel_format_channels(PixelFormat fmt) {
+    switch (fmt) {
+        case PixelFormat::Gray8:
+        case PixelFormat::Gray16:  return 1;
+        case PixelFormat::RGB8:
+        case PixelFormat::RGB16:   return 3;
+        case PixelFormat::RGBA8:
+        case PixelFormat::RGBA16:  return 4;
+    }
+    return 3;
+}
+
+bool avframe_to_image(AVFrame* frame,
+                      Image& image,
+                      SourceFormat src_format,
+                      std::uint32_t flags,
+                      bool icc_profile_present,
+                      std::string& err) {
+    AVPixelFormat target_av_fmt = AV_PIX_FMT_NONE;
+    PixelFormat target_fmt = select_target_pixel_format(
+        static_cast<AVPixelFormat>(frame->format), flags, target_av_fmt);
+
+    int channels = pixel_format_channels(target_fmt);
+    int bit_depth = (target_fmt == PixelFormat::RGB16 ||
+                     target_fmt == PixelFormat::RGBA16) ? 16 : 8;
+    int cv_type = (bit_depth == 16) ? CV_16UC(channels) : CV_8UC(channels);
+
+    cv::Mat mat(frame->height, frame->width, cv_type);
+    if (mat.empty()) {
+        err = "cv::Mat allocation failed";
+        return false;
+    }
+
+    SwsContextPtr sws(sws_getContext(
+        frame->width, frame->height,
+        static_cast<AVPixelFormat>(frame->format),
+        frame->width, frame->height,
+        target_av_fmt,
+        SWS_BILINEAR, nullptr, nullptr, nullptr));
+    if (!sws) {
+        err = "sws_getContext failed";
+        return false;
+    }
+
+    uint8_t* dst_data[4]   = {mat.ptr(), nullptr, nullptr, nullptr};
+    int      dst_strides[4] = {static_cast<int>(mat.step[0]), 0, 0, 0};
+    int rc = sws_scale(sws.get(),
+                       frame->data, frame->linesize,
+                       0, frame->height,
+                       dst_data, dst_strides);
+    if (rc <= 0) {
+        err = "sws_scale produced no output";
+        return false;
+    }
+
+    auto& impl = image.internal();
+    impl.info.width            = frame->width;
+    impl.info.height           = frame->height;
+    impl.info.pixel_format     = target_fmt;
+    impl.info.bit_depth        = bit_depth;
+    impl.info.has_alpha        = (channels == 4);
+    impl.info.color_space      = "sRGB";
+    impl.info.source_format    = src_format;
+
+    // Record the source bit depth so the UI can show "10-bit AVIF"
+    // even when we tone-mapped down to RGB8.
+    const AVPixFmtDescriptor* src_desc =
+        av_pix_fmt_desc_get(static_cast<AVPixelFormat>(frame->format));
+    if (src_desc && src_desc->nb_components > 0) {
+        impl.info.source_bit_depth = src_desc->comp[0].depth;
+    }
+
+    if (icc_profile_present) {
+        impl.info.icc_profile_name = "Embedded ICC";
+    }
+
+    impl.mat = std::move(mat);
+    return true;
+}
+
+// ============================================================================
+// ICC profile detection
+// ============================================================================
+
+bool stream_group_has_icc(const AVStreamGroup* stg) {
+    if (!stg || stg->type != AV_STREAM_GROUP_PARAMS_TILE_GRID) return false;
+    const AVStreamGroupTileGrid* grid = stg->params.tile_grid;
+    if (!grid) return false;
+    for (int i = 0; i < grid->nb_coded_side_data; ++i) {
+        if (grid->coded_side_data[i].type == AV_PKT_DATA_ICC_PROFILE) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool stream_has_icc(const AVStream* st) {
+    if (!st || !st->codecpar) return false;
+    for (int i = 0; i < st->codecpar->nb_coded_side_data; ++i) {
+        if (st->codecpar->coded_side_data[i].type == AV_PKT_DATA_ICC_PROFILE) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool frame_has_icc(const AVFrame* f) {
+    if (!f) return false;
+    for (int i = 0; i < f->nb_side_data; ++i) {
+        if (f->side_data[i]->type == AV_FRAME_DATA_ICC_PROFILE) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// ============================================================================
+// Multi-tile vs single-tile dispatch
+// ============================================================================
+
+const AVStreamGroup* find_tile_grid_group(AVFormatContext* fmt_ctx) {
+    for (unsigned int i = 0; i < fmt_ctx->nb_stream_groups; ++i) {
+        AVStreamGroup* stg = fmt_ctx->stream_groups[i];
+        if (stg && stg->type == AV_STREAM_GROUP_PARAMS_TILE_GRID) {
+            return stg;
+        }
+    }
+    return nullptr;
+}
+
+std::unique_ptr<Image> decode_tile_grid(AVFormatContext* fmt_ctx,
+                                        const AVStreamGroup* stg,
+                                        SourceFormat src_format,
+                                        std::uint32_t flags,
+                                        std::string& err) {
+    const AVStreamGroupTileGrid* grid = stg->params.tile_grid;
+    if (!grid || grid->nb_tiles == 0) {
+        err = "tile grid is empty";
+        return nullptr;
+    }
+
+    if (grid->nb_tiles != stg->nb_streams) {
+        char buf[96];
+        std::snprintf(buf, sizeof(buf),
+                      "tile grid: nb_tiles %u != group->nb_streams %u",
+                      grid->nb_tiles,
+                      static_cast<unsigned>(stg->nb_streams));
+        err = buf;
+        return nullptr;
+    }
+
+    // ---- decode every tile to an AVFrame ----
+    std::vector<AVFramePtr> tile_frames;
+    tile_frames.reserve(grid->nb_tiles);
+    for (unsigned int i = 0; i < grid->nb_tiles; ++i) {
+        unsigned int local_idx = grid->offsets[i].idx;
+        if (local_idx >= stg->nb_streams) {
+            char buf[96];
+            std::snprintf(buf, sizeof(buf),
+                          "tile %u: offsets.idx %u out of range",
+                          i, local_idx);
+            err = buf;
+            return nullptr;
+        }
+        AVStream* st = stg->streams[local_idx];
+        std::string tile_err;
+        AVFramePtr frame = decode_one_frame(fmt_ctx, st->index, tile_err);
+        if (!frame) {
+            char prefix[96];
+            std::snprintf(prefix, sizeof(prefix),
+                          "tile %u (stream %d)", i, st->index);
+            err = std::string(prefix) + ": " + tile_err;
+            return nullptr;
+        }
+        tile_frames.push_back(std::move(frame));
+    }
+
+    // ---- build assembler ----
+    HeifTileAssembler assembler;
+    std::vector<HeifTileInputDesc> inputs;
+    inputs.reserve(grid->nb_tiles);
+    for (size_t i = 0; i < tile_frames.size(); ++i) {
+        AVFrame* f = tile_frames[i].get();
+        HeifTileInputDesc d;
+        d.width   = f->width;
+        d.height  = f->height;
+        d.pix_fmt = static_cast<AVPixelFormat>(f->format);
+        if (f->sample_aspect_ratio.num && f->sample_aspect_ratio.den) {
+            d.sar = f->sample_aspect_ratio;
+        }
+        // HEIF stills have no real timebase; xstack only requires that
+        // every input shares one, so {1,1} on every src is fine.
+        d.time_base = AVRational{1, 1};
+        inputs.push_back(d);
+    }
+
+    // Pick sink pix_fmt based on caller flags.
+    AVPixelFormat sink_av_fmt = AV_PIX_FMT_NONE;
+    select_target_pixel_format(
+        static_cast<AVPixelFormat>(tile_frames[0]->format), flags, sink_av_fmt);
+
+    if (!assembler.configure(grid, inputs, sink_av_fmt, err)) {
+        return nullptr;
+    }
+
+    std::vector<AVFrame*> raw_frames;
+    raw_frames.reserve(tile_frames.size());
+    for (auto& p : tile_frames) raw_frames.push_back(p.get());
+
+    AVFramePtr composed(assembler.assemble(raw_frames, err));
+    if (!composed) return nullptr;
+
+    bool has_icc = stream_group_has_icc(stg);
+
+    auto image = std::make_unique<Image>();
+    if (!avframe_to_image(composed.get(), *image,
+                          src_format, flags, has_icc, err)) {
+        return nullptr;
+    }
+    return image;
+}
+
+std::unique_ptr<Image> decode_single_stream(AVFormatContext* fmt_ctx,
+                                            int stream_index,
+                                            SourceFormat src_format,
+                                            std::uint32_t flags,
+                                            std::string& err) {
+    AVFramePtr frame = decode_one_frame(fmt_ctx, stream_index, err);
+    if (!frame) return nullptr;
+
+    bool has_icc = stream_has_icc(fmt_ctx->streams[stream_index]) ||
+                   frame_has_icc(frame.get());
+
+    auto image = std::make_unique<Image>();
+    if (!avframe_to_image(frame.get(), *image,
+                          src_format, flags, has_icc, err)) {
+        return nullptr;
+    }
+    return image;
+}
+
+} // namespace
+
+// ============================================================================
+// Public entry point
+// ============================================================================
+
+std::unique_ptr<Image> load_heif_avif_from_memory(const uint8_t* data,
+                                                  std::size_t size,
+                                                  SourceFormat fmt,
+                                                  std::uint32_t flags,
+                                                  std::string& err) {
+    err.clear();
+    if (!data || size == 0) {
+        err = "empty input buffer";
+        return nullptr;
+    }
+
+    // ---- AVIO: in-memory reader ----
+    constexpr int avio_buf_size = 4096;
+    auto* avio_buf = static_cast<unsigned char*>(av_malloc(avio_buf_size));
+    if (!avio_buf) {
+        err = "av_malloc(AVIO buffer) failed";
+        return nullptr;
+    }
+
+    // The MemReader is owned here and outlives the AVIOContext: the
+    // unique_ptr below frees the AVIO context on every return path,
+    // and the reader struct is on the stack so it goes away after.
+    MemReader reader{data, size, 0};
+
+    AVIOContext* raw_avio = avio_alloc_context(
+        avio_buf, avio_buf_size,
+        /*write_flag*/ 0,
+        &reader,
+        &memreader_read,
+        /*write_packet*/ nullptr,
+        &memreader_seek);
+    if (!raw_avio) {
+        av_free(avio_buf);
+        err = "avio_alloc_context failed";
+        return nullptr;
+    }
+    AVIOContextPtr avio_ctx(raw_avio);
+
+    // ---- AVFormatContext open ----
+    AVFormatContext* raw_fmt = avformat_alloc_context();
+    if (!raw_fmt) {
+        err = "avformat_alloc_context failed";
+        return nullptr;
+    }
+    raw_fmt->pb = avio_ctx.get();
+    raw_fmt->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+    // Try the AVIF demuxer first when the caller already knows the
+    // format -- saves probing costs and is required for some bare
+    // AVIF still images that lack a strong signature.
+    const AVInputFormat* hint = nullptr;
+    if (fmt == SourceFormat::AVIF) {
+        hint = av_find_input_format("avif");
+    } else if (fmt == SourceFormat::HEIF) {
+        // HEIF lives inside the mov demuxer in current FFmpeg builds.
+        hint = av_find_input_format("mov");
+    }
+
+    if (int ret = avformat_open_input(&raw_fmt, /*url*/ nullptr, hint, nullptr);
+        ret < 0) {
+        // avformat_open_input frees raw_fmt on failure; do NOT
+        // double-free below.
+        set_av_err(err, "avformat_open_input failed", ret);
+        return nullptr;
+    }
+    AVFormatContextPtr fmt_ctx(raw_fmt);
+
+    if (int ret = avformat_find_stream_info(fmt_ctx.get(), nullptr); ret < 0) {
+        set_av_err(err, "avformat_find_stream_info failed", ret);
+        return nullptr;
+    }
+
+    // ---- pick the main image entry ----
+    if (const AVStreamGroup* stg = find_tile_grid_group(fmt_ctx.get())) {
+        const AVStreamGroupTileGrid* grid = stg->params.tile_grid;
+
+        // Single-tile grids are equivalent to a primary item with no
+        // composition needed.  Take the fast path.
+        if (grid && grid->nb_tiles == 1 && stg->nb_streams >= 1) {
+            int stream_idx = stg->streams[0]->index;
+            return decode_single_stream(fmt_ctx.get(), stream_idx,
+                                        fmt, flags, err);
+        }
+
+        return decode_tile_grid(fmt_ctx.get(), stg, fmt, flags, err);
+    }
+
+    // Fallback: no tile-grid group, so pick the best video stream and
+    // decode its primary frame.
+    int best = av_find_best_stream(fmt_ctx.get(), AVMEDIA_TYPE_VIDEO,
+                                   -1, -1, nullptr, 0);
+    if (best < 0) {
+        set_av_err(err, "av_find_best_stream failed", best);
+        return nullptr;
+    }
+    return decode_single_stream(fmt_ctx.get(), best, fmt, flags, err);
+}
+
+} // namespace idiff
+
+#endif // IDIFF_HAVE_FFMPEG_IMAGE_DECODE

--- a/src/core/detail/ffmpeg_image_loader.h
+++ b/src/core/detail/ffmpeg_image_loader.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef IDIFF_FFMPEG_IMAGE_LOADER_H
+#define IDIFF_FFMPEG_IMAGE_LOADER_H
+
+#ifdef IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "core/image.h"
+
+namespace idiff {
+
+// Decode a HEIF / AVIF still image from a memory buffer using
+// libavformat + libavcodec (+ libavfilter for tile-grid composition).
+//
+// Behaviour:
+//   * Opens the buffer as an in-memory AVFormatContext (no file path
+//     traffic, so non-ASCII paths on Windows are not a problem).
+//   * Prefers an AV_STREAM_GROUP_PARAMS_TILE_GRID stream group as
+//     the main image entry point; if the file has none (single-tile
+//     primary item) falls back to av_find_best_stream(VIDEO).
+//   * Decodes every tile stream to one AVFrame each.
+//   * Multi-tile path: composes the tiles via HeifTileAssembler
+//     (libavfilter xstack + crop) into a single AVFrame.
+//   * Single-tile path: skips the filter graph entirely.
+//   * Converts the final AVFrame to RGB24 / RGBA / RGB48LE / RGBA64LE
+//     and fills an Image (cv::Mat + ImageInfo) compatible with the
+//     rest of the idiff pipeline.
+//
+// `flags` is a bitwise-OR of LoadFlag values from image_loader.h --
+// LoadFlag::Keep16Bit and LoadFlag::KeepAlpha decide the target
+// pixel format.  ICC profile presence is recorded via
+// `info.icc_profile_name = "Embedded ICC"` when found, but never
+// applied (matching the ImageMagick path's "tag, don't transform"
+// convention).
+//
+// On failure, returns nullptr and fills `err` with a human-readable
+// message that already includes the failing tile / stream index.
+//
+// Thread safety: re-entrant; each call constructs its own contexts.
+std::unique_ptr<Image> load_heif_avif_from_memory(const uint8_t* data,
+                                                  std::size_t size,
+                                                  SourceFormat fmt,
+                                                  std::uint32_t flags,
+                                                  std::string& err);
+
+} // namespace idiff
+
+#endif // IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+#endif // IDIFF_FFMPEG_IMAGE_LOADER_H

--- a/src/core/detail/heif_tile_assembler.cpp
+++ b/src/core/detail/heif_tile_assembler.cpp
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: BSD-2-Clause
+#ifdef IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+
+#include "core/detail/heif_tile_assembler.h"
+
+#include "util/logger.h"
+
+extern "C" {
+#include <libavfilter/avfilter.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavformat/avformat.h>
+#include <libavutil/frame.h>
+#include <libavutil/opt.h>
+#include <libavutil/pixdesc.h>
+}
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace idiff {
+
+namespace {
+
+void set_av_err(std::string& err, const char* prefix, int ret) {
+    char buf[128];
+    av_strerror(ret, buf, sizeof(buf));
+    err = std::string(prefix) + ": " + buf;
+}
+
+const char* pix_fmt_name(AVPixelFormat fmt) {
+    const char* n = av_get_pix_fmt_name(fmt);
+    return n ? n : "?";
+}
+
+} // namespace
+
+struct HeifTileAssembler::Impl {
+    AVFilterGraph* graph = nullptr;
+    std::vector<AVFilterContext*> src_ctxs;  // one per tile, same order as grid->offsets
+    AVFilterContext* sink_ctx = nullptr;
+
+    bool configured = false;
+
+    // Logged once per assemble() so debug-level output traces every
+    // composition, while info-level logs stay quiet.  Saved at
+    // configure() time because the underlying grid pointer is owned
+    // by the AVFormatContext and may be freed before assemble().
+    int nb_tiles = 0;
+    int coded_w = 0, coded_h = 0;
+    int out_w = 0, out_h = 0;
+
+    void close() noexcept {
+        if (graph) {
+            avfilter_graph_free(&graph);  // also frees src/sink ctxs
+        }
+        src_ctxs.clear();
+        sink_ctx = nullptr;
+        configured = false;
+    }
+};
+
+HeifTileAssembler::HeifTileAssembler() : impl_(std::make_unique<Impl>()) {}
+
+HeifTileAssembler::~HeifTileAssembler() {
+    if (impl_) impl_->close();
+}
+
+bool HeifTileAssembler::is_configured() const noexcept {
+    return impl_ && impl_->configured;
+}
+
+void HeifTileAssembler::reset() noexcept {
+    if (impl_) impl_->close();
+}
+
+bool HeifTileAssembler::configure(const AVStreamGroupTileGrid* grid,
+                                  const std::vector<HeifTileInputDesc>& inputs,
+                                  AVPixelFormat out_pix_fmt,
+                                  std::string& err) {
+    impl_->close();
+
+    if (!grid) {
+        err = "null tile grid";
+        return false;
+    }
+    if (grid->nb_tiles == 0) {
+        err = "tile grid has zero tiles";
+        return false;
+    }
+    if (inputs.size() != grid->nb_tiles) {
+        char buf[96];
+        std::snprintf(buf, sizeof(buf),
+                      "input descriptor count %zu != nb_tiles %u",
+                      inputs.size(),
+                      static_cast<unsigned>(grid->nb_tiles));
+        err = buf;
+        return false;
+    }
+    if (out_pix_fmt == AV_PIX_FMT_NONE) {
+        err = "invalid output pixel format";
+        return false;
+    }
+
+    impl_->graph = avfilter_graph_alloc();
+    if (!impl_->graph) {
+        err = "avfilter_graph_alloc failed";
+        return false;
+    }
+
+    const AVFilter* buffer_filter   = avfilter_get_by_name("buffer");
+    const AVFilter* xstack_filter   = avfilter_get_by_name("xstack");
+    const AVFilter* crop_filter     = avfilter_get_by_name("crop");
+    const AVFilter* buffersink_flt  = avfilter_get_by_name("buffersink");
+    if (!buffer_filter || !xstack_filter || !crop_filter || !buffersink_flt) {
+        err = "buffer/xstack/crop/buffersink filter not registered";
+        impl_->close();
+        return false;
+    }
+
+    // ---- N buffer sources -----------------------------------------------
+    impl_->src_ctxs.reserve(grid->nb_tiles);
+    for (unsigned int i = 0; i < grid->nb_tiles; ++i) {
+        char name[32];
+        std::snprintf(name, sizeof(name), "tile_in_%u", i);
+        AVFilterContext* src = avfilter_graph_alloc_filter(
+            impl_->graph, buffer_filter, name);
+        if (!src) {
+            err = "buffer src alloc failed";
+            impl_->close();
+            return false;
+        }
+
+        const HeifTileInputDesc& d = inputs[i];
+        if (d.width <= 0 || d.height <= 0 || d.pix_fmt == AV_PIX_FMT_NONE) {
+            char buf[96];
+            std::snprintf(buf, sizeof(buf),
+                          "tile %u: invalid input descriptor", i);
+            err = buf;
+            impl_->close();
+            return false;
+        }
+
+        const AVRational tb = (d.time_base.num && d.time_base.den)
+            ? d.time_base : AVRational{1, 1};
+        const AVRational sar = (d.sar.num && d.sar.den)
+            ? d.sar : AVRational{1, 1};
+
+        int rc = 0;
+        rc |= av_opt_set_int(src, "width",  d.width,
+                             AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set_int(src, "height", d.height,
+                             AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set_int(src, "pix_fmt", static_cast<int>(d.pix_fmt),
+                             AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set_q(src, "time_base", tb, AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set_q(src, "pixel_aspect", sar,
+                           AV_OPT_SEARCH_CHILDREN);
+        if (rc != 0) {
+            err = "buffer src option set failed";
+            impl_->close();
+            return false;
+        }
+
+        if (int ret = avfilter_init_str(src, nullptr); ret < 0) {
+            set_av_err(err, "buffer src init failed", ret);
+            impl_->close();
+            return false;
+        }
+        impl_->src_ctxs.push_back(src);
+    }
+
+    // ---- xstack ----------------------------------------------------------
+    //
+    // layout = "x0_y0|x1_y1|...|x_{N-1}_y_{N-1}"  -- absolute pixel
+    // offsets per input.  fill = "0xRRGGBB@0xAA" gives xstack the
+    // canvas background colour (matches grid->background[]).
+    //
+    // We let xstack's `inputs=N` produce exactly N input pads; the
+    // canvas size is implied by max(x_i + w_i, y_i + h_i) but we
+    // crop to (coded_w x coded_h) below to handle the (rare) case
+    // where the encoded canvas is taller than the union of tiles
+    // (that gap is what `background` is intended to fill).
+
+    AVFilterContext* xstack_ctx = avfilter_graph_alloc_filter(
+        impl_->graph, xstack_filter, "xstack");
+    if (!xstack_ctx) {
+        err = "xstack alloc failed";
+        impl_->close();
+        return false;
+    }
+
+    std::string layout;
+    layout.reserve(grid->nb_tiles * 16);
+    for (unsigned int i = 0; i < grid->nb_tiles; ++i) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%d_%d",
+                      grid->offsets[i].horizontal,
+                      grid->offsets[i].vertical);
+        if (i) layout += '|';
+        layout += buf;
+    }
+
+    char fill[32];
+    std::snprintf(fill, sizeof(fill), "0x%02X%02X%02X@0x%02X",
+                  grid->background[0], grid->background[1],
+                  grid->background[2], grid->background[3]);
+
+    {
+        int rc = 0;
+        rc |= av_opt_set_int(xstack_ctx, "inputs", grid->nb_tiles,
+                             AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set(xstack_ctx, "layout", layout.c_str(),
+                         AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set(xstack_ctx, "fill", fill,
+                         AV_OPT_SEARCH_CHILDREN);
+        if (rc != 0) {
+            err = "xstack rejected one or more options";
+            impl_->close();
+            return false;
+        }
+    }
+
+    if (int ret = avfilter_init_str(xstack_ctx, nullptr); ret < 0) {
+        set_av_err(err, "xstack init failed", ret);
+        impl_->close();
+        return false;
+    }
+
+    // ---- crop ------------------------------------------------------------
+    //
+    // Trim xstack's coded canvas down to grid->{width,height} starting
+    // at (horizontal_offset, vertical_offset).  We always insert the
+    // crop -- when no crop is required, configure() should set
+    // those parameters to a no-op (full canvas), but the assembler
+    // does not assume that.
+
+    AVFilterContext* crop_ctx = avfilter_graph_alloc_filter(
+        impl_->graph, crop_filter, "crop");
+    if (!crop_ctx) {
+        err = "crop alloc failed";
+        impl_->close();
+        return false;
+    }
+
+    {
+        char wbuf[16], hbuf[16], xbuf[16], ybuf[16];
+        // Resolve to coded canvas if width/height are zero, which can
+        // happen on malformed inputs.
+        const int w = (grid->width  > 0) ? grid->width  : grid->coded_width;
+        const int h = (grid->height > 0) ? grid->height : grid->coded_height;
+        std::snprintf(wbuf, sizeof(wbuf), "%d", w);
+        std::snprintf(hbuf, sizeof(hbuf), "%d", h);
+        std::snprintf(xbuf, sizeof(xbuf), "%d", grid->horizontal_offset);
+        std::snprintf(ybuf, sizeof(ybuf), "%d", grid->vertical_offset);
+
+        int rc = 0;
+        rc |= av_opt_set(crop_ctx, "w", wbuf, AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set(crop_ctx, "h", hbuf, AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set(crop_ctx, "x", xbuf, AV_OPT_SEARCH_CHILDREN);
+        rc |= av_opt_set(crop_ctx, "y", ybuf, AV_OPT_SEARCH_CHILDREN);
+        if (rc != 0) {
+            err = "crop rejected one or more options";
+            impl_->close();
+            return false;
+        }
+
+        impl_->out_w = w;
+        impl_->out_h = h;
+    }
+
+    if (int ret = avfilter_init_str(crop_ctx, nullptr); ret < 0) {
+        set_av_err(err, "crop init failed", ret);
+        impl_->close();
+        return false;
+    }
+
+    // ---- buffersink ------------------------------------------------------
+    //
+    // Constrain the sink to a single packed pixel format.  libavfilter
+    // will auto-insert a `format` (and, if needed, `scale`) node ahead
+    // of the sink to satisfy the constraint -- exactly what we want
+    // for "give me RGB24 / RGBA / RGB48LE / RGBA64LE no matter what
+    // the source YUV layout was".
+
+    impl_->sink_ctx = avfilter_graph_alloc_filter(
+        impl_->graph, buffersink_flt, "out");
+    if (!impl_->sink_ctx) {
+        err = "buffer sink alloc failed";
+        impl_->close();
+        return false;
+    }
+
+    {
+        const AVPixelFormat sink_pix_fmts[] = {out_pix_fmt};
+        if (int ret = av_opt_set_array(
+                impl_->sink_ctx, "pixel_formats",
+                AV_OPT_SEARCH_CHILDREN,
+                0, 1, AV_OPT_TYPE_PIXEL_FMT, sink_pix_fmts);
+            ret < 0) {
+            set_av_err(err, "buffer sink pixel_formats set failed", ret);
+            impl_->close();
+            return false;
+        }
+    }
+
+    if (int ret = avfilter_init_str(impl_->sink_ctx, nullptr); ret < 0) {
+        set_av_err(err, "buffer sink init failed", ret);
+        impl_->close();
+        return false;
+    }
+
+    // ---- linking ---------------------------------------------------------
+    //
+    // src_i -> xstack:i, xstack:0 -> crop:0 -> sink:0.
+
+    for (unsigned int i = 0; i < grid->nb_tiles; ++i) {
+        if (int ret = avfilter_link(impl_->src_ctxs[i], 0,
+                                    xstack_ctx, i);
+            ret < 0) {
+            char prefix[64];
+            std::snprintf(prefix, sizeof(prefix),
+                          "link tile %u -> xstack failed", i);
+            set_av_err(err, prefix, ret);
+            impl_->close();
+            return false;
+        }
+    }
+    if (int ret = avfilter_link(xstack_ctx, 0, crop_ctx, 0); ret < 0) {
+        set_av_err(err, "link xstack -> crop failed", ret);
+        impl_->close();
+        return false;
+    }
+    if (int ret = avfilter_link(crop_ctx, 0, impl_->sink_ctx, 0); ret < 0) {
+        set_av_err(err, "link crop -> sink failed", ret);
+        impl_->close();
+        return false;
+    }
+
+    if (int ret = avfilter_graph_config(impl_->graph, nullptr); ret < 0) {
+        set_av_err(err, "graph config failed", ret);
+        impl_->close();
+        return false;
+    }
+
+    impl_->nb_tiles = static_cast<int>(grid->nb_tiles);
+    impl_->coded_w  = grid->coded_width;
+    impl_->coded_h  = grid->coded_height;
+    impl_->configured = true;
+
+    LOG_INFO("HeifTileAssembler: configured %d tiles, "
+             "canvas %dx%d -> cropped %dx%d, sink=%s",
+             impl_->nb_tiles, impl_->coded_w, impl_->coded_h,
+             impl_->out_w, impl_->out_h,
+             pix_fmt_name(out_pix_fmt));
+    return true;
+}
+
+AVFrame* HeifTileAssembler::assemble(const std::vector<AVFrame*>& tiles,
+                                     std::string& err) {
+    if (!is_configured()) {
+        err = "assembler not configured";
+        return nullptr;
+    }
+    if (tiles.size() != impl_->src_ctxs.size()) {
+        char buf[96];
+        std::snprintf(buf, sizeof(buf),
+                      "tile frame count %zu != configured inputs %zu",
+                      tiles.size(), impl_->src_ctxs.size());
+        err = buf;
+        return nullptr;
+    }
+
+    // Push every tile.  KEEP_REF so the caller's frames are not
+    // consumed; the graph holds its own refs internally.
+    for (size_t i = 0; i < tiles.size(); ++i) {
+        AVFrame* f = tiles[i];
+        if (!f) {
+            char buf[64];
+            std::snprintf(buf, sizeof(buf), "tile %zu: null frame", i);
+            err = buf;
+            return nullptr;
+        }
+        if (int ret = av_buffersrc_add_frame_flags(
+                impl_->src_ctxs[i], f, AV_BUFFERSRC_FLAG_KEEP_REF);
+            ret < 0) {
+            char prefix[64];
+            std::snprintf(prefix, sizeof(prefix),
+                          "tile %zu: buffersrc add_frame failed", i);
+            set_av_err(err, prefix, ret);
+            return nullptr;
+        }
+    }
+
+    // Pull the single composed output frame.  xstack waits until it
+    // has one frame on every input pad, so a single get_frame call is
+    // enough; we do not need to drain in a loop.
+    AVFrame* out = av_frame_alloc();
+    if (!out) {
+        err = "av_frame_alloc failed";
+        return nullptr;
+    }
+    if (int ret = av_buffersink_get_frame(impl_->sink_ctx, out); ret < 0) {
+        set_av_err(err, "buffersink get_frame failed", ret);
+        av_frame_free(&out);
+        return nullptr;
+    }
+
+    LOG_DEBUG("HeifTileAssembler: assembled %d tiles "
+              "(canvas %dx%d -> output %dx%d)",
+              impl_->nb_tiles, impl_->coded_w, impl_->coded_h,
+              out->width, out->height);
+    return out;
+}
+
+} // namespace idiff
+
+#endif // IDIFF_HAVE_FFMPEG_IMAGE_DECODE

--- a/src/core/detail/heif_tile_assembler.h
+++ b/src/core/detail/heif_tile_assembler.h
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BSD-2-Clause
+#ifndef IDIFF_HEIF_TILE_ASSEMBLER_H
+#define IDIFF_HEIF_TILE_ASSEMBLER_H
+
+#ifdef IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+
+#include <memory>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include <libavutil/pixfmt.h>
+#include <libavutil/rational.h>
+}
+
+struct AVFrame;
+struct AVStreamGroupTileGrid;
+
+namespace idiff {
+
+// Per-tile buffer source description handed to configure().  The
+// assembler builds one `buffer` filter per entry, all feeding into a
+// single xstack node whose layout mirrors the on-disk tile grid.
+struct HeifTileInputDesc {
+    int width = 0;
+    int height = 0;
+    AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
+    AVRational sar{1, 1};
+    AVRational time_base{1, 1};
+};
+
+// Wrapper around a one-shot HEIF tile-grid composition graph:
+//
+//   [in0][in1]...[in_{N-1}]
+//     xstack=inputs=N:layout=...:fill=0xRRGGBB@0xAA,
+//     crop=W:H:hoff:voff,
+//     format=<sink_pix_fmt>
+//   [out]
+//
+// HEIF / AVIF demuxers expose every tile as an independent AVStream
+// plus an AVStreamGroupTileGrid descriptor.  libav* itself never
+// composes the tiles; assembling the full image is the caller's job.
+// idiff defers to libavfilter's xstack here for two reasons: it is
+// the same path fftools uses (so behaviour matches the ffmpeg CLI on
+// edge cases like non-grid offsets and partial-tile padding), and it
+// trivially handles 4:2:0 / 4:2:2 / 4:4:4 chroma subsampling and
+// 10/12-bit depths without idiff having to re-implement the chroma
+// alignment rules.
+//
+// Use:
+//   HeifTileAssembler asm;
+//   if (!asm.configure(grid, inputs, AV_PIX_FMT_RGB24, err)) ...
+//   AVFrame* big = asm.assemble(tile_frames, err);
+//
+// `inputs` must have exactly grid->nb_tiles entries, in the same
+// order as grid->offsets[].  `tile_frames` passed to assemble() must
+// match the inputs by index.
+//
+// Thread safety: not thread-safe; serialise externally.
+class HeifTileAssembler {
+public:
+    HeifTileAssembler();
+    ~HeifTileAssembler();
+
+    HeifTileAssembler(const HeifTileAssembler&) = delete;
+    HeifTileAssembler& operator=(const HeifTileAssembler&) = delete;
+    HeifTileAssembler(HeifTileAssembler&&) = delete;
+    HeifTileAssembler& operator=(HeifTileAssembler&&) = delete;
+
+    // Build the graph for a particular grid.  `out_pix_fmt` is the
+    // pixel format the buffersink is constrained to; the caller
+    // should pick a packed RGB(A) format compatible with the rest
+    // of idiff's image pipeline (RGB24 / RGBA / RGB48LE / RGBA64LE).
+    // Returns true on success; on failure, fills `err` and leaves
+    // the assembler in a closed state.
+    bool configure(const AVStreamGroupTileGrid* grid,
+                   const std::vector<HeifTileInputDesc>& inputs,
+                   AVPixelFormat out_pix_fmt,
+                   std::string& err);
+
+    bool is_configured() const noexcept;
+
+    // Push one tile per buffersrc, then pull a single output frame.
+    // `tiles` must have the same length and order as the `inputs`
+    // vector previously handed to configure().  The caller retains
+    // ownership of `tiles[i]`; the graph takes its own refs.
+    //
+    // Returns a freshly allocated AVFrame on success (caller must
+    // av_frame_free()), or nullptr on failure with `err` filled in.
+    AVFrame* assemble(const std::vector<AVFrame*>& tiles,
+                      std::string& err);
+
+    // Tear down the graph and release all internal contexts.
+    void reset() noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace idiff
+
+#endif // IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+#endif // IDIFF_HEIF_TILE_ASSEMBLER_H

--- a/src/core/image.h
+++ b/src/core/image.h
@@ -26,6 +26,8 @@ enum class SourceFormat {
     TIFF,
     BMP,
     RAW,
+    HEIF,
+    AVIF,
     Unknown,
 };
 

--- a/src/core/image_loader.cpp
+++ b/src/core/image_loader.cpp
@@ -15,6 +15,10 @@
 
 #include "core/detail/raw_loader.h"
 
+#ifdef IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+#include "core/detail/ffmpeg_image_loader.h"
+#endif
+
 namespace idiff {
 
 namespace {
@@ -39,6 +43,9 @@ SourceFormat extension_to_format(const std::string& path) {
     if (ext == ".webp") return SourceFormat::WebP;
     if (ext == ".tif" || ext == ".tiff") return SourceFormat::TIFF;
     if (ext == ".bmp")  return SourceFormat::BMP;
+    if (ext == ".heic" || ext == ".heif" || ext == ".hif")
+        return SourceFormat::HEIF;
+    if (ext == ".avif") return SourceFormat::AVIF;
 
     for (const auto* raw_ext : raw_extensions) {
         if (ext == raw_ext) return SourceFormat::RAW;
@@ -198,6 +205,12 @@ bool ImageLoader::has_backend(LoaderBackend backend) noexcept {
 #else
             return false;
 #endif
+        case LoaderBackend::FFmpeg:
+#ifdef IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+            return true;
+#else
+            return false;
+#endif
     }
     return false;
 }
@@ -214,6 +227,7 @@ const char* ImageLoader::backend_name(LoaderBackend backend) noexcept {
     switch (backend) {
         case LoaderBackend::ImageMagick: return "ImageMagick";
         case LoaderBackend::OpenCV:      return "OpenCV";
+        case LoaderBackend::FFmpeg:      return "FFmpeg";
     }
     return "Unknown";
 }
@@ -247,46 +261,49 @@ std::unique_ptr<Image> ImageLoader::load(const std::string& path) {
         return img;
     }
 
-    // Try preferred backend first, then fall back to the other one.
-    LoaderBackend primary = preferred_;
-    LoaderBackend secondary = (primary == LoaderBackend::ImageMagick)
-        ? LoaderBackend::OpenCV : LoaderBackend::ImageMagick;
+    // Build the backend priority list.  HEIF/AVIF prefers the FFmpeg
+    // backend (libav* is far more reliable than ImageMagick HEIF
+    // delegates on Windows/vcpkg); everything else keeps the historic
+    // ImageMagick -> OpenCV order honoured by `preferred_`.
+    LoaderBackend candidates[3];
+    int nb = 0;
+    if (is_heif_family(path)) {
+        candidates[nb++] = LoaderBackend::FFmpeg;
+        candidates[nb++] = LoaderBackend::ImageMagick;
+        candidates[nb++] = LoaderBackend::OpenCV;
+    } else {
+        LoaderBackend primary = preferred_;
+        LoaderBackend secondary = (primary == LoaderBackend::ImageMagick)
+            ? LoaderBackend::OpenCV : LoaderBackend::ImageMagick;
+        candidates[nb++] = primary;
+        candidates[nb++] = secondary;
+    }
 
-    if (has_backend(primary)) {
-        std::string saved_err = last_error_;
-        auto img = load_with_backend(path, primary);
+    // Try each compiled-in backend in order; collect every error so
+    // the caller sees which backends were attempted.
+    std::string combined;
+    int tried = 0;
+    for (int i = 0; i < nb; ++i) {
+        LoaderBackend b = candidates[i];
+        if (!has_backend(b)) continue;
+        last_error_.clear();
+        auto img = load_with_backend(path, b);
         if (img) {
-            last_used_ = primary;
+            last_used_ = b;
             return img;
         }
-        // Preserve the primary error for reporting if fallback also fails.
-        saved_err = last_error_;
-        if (has_backend(secondary)) {
-            last_error_.clear();
-            img = load_with_backend(path, secondary);
-            if (img) {
-                last_used_ = secondary;
-                return img;
-            }
-            // Both failed -- compose a combined error.
-            last_error_ = std::string(backend_name(primary)) + ": " + saved_err
-                + "; " + backend_name(secondary) + ": " + last_error_;
-        } else {
-            last_error_ = saved_err;
-        }
-        return nullptr;
+        if (!combined.empty()) combined += "; ";
+        combined += backend_name(b);
+        combined += ": ";
+        combined += last_error_;
+        ++tried;
     }
 
-    // Preferred backend is not compiled in (should not normally happen
-    // since set_preferred_backend snaps to a valid one) -- use whichever
-    // is available.
-    if (has_backend(secondary)) {
-        auto img = load_with_backend(path, secondary);
-        if (img) last_used_ = secondary;
-        return img;
+    if (tried == 0) {
+        last_error_ = "No image loader backend is available";
+    } else {
+        last_error_ = std::move(combined);
     }
-
-    last_error_ = "No image loader backend is available";
     return nullptr;
 }
 
@@ -299,39 +316,43 @@ std::unique_ptr<Image> ImageLoader::load_from_memory(const uint8_t* data, size_t
         return nullptr;
     }
 
-    LoaderBackend primary = preferred_;
-    LoaderBackend secondary = (primary == LoaderBackend::ImageMagick)
-        ? LoaderBackend::OpenCV : LoaderBackend::ImageMagick;
+    LoaderBackend candidates[3];
+    int nb = 0;
+    if (is_heif_family(format)) {
+        candidates[nb++] = LoaderBackend::FFmpeg;
+        candidates[nb++] = LoaderBackend::ImageMagick;
+        candidates[nb++] = LoaderBackend::OpenCV;
+    } else {
+        LoaderBackend primary = preferred_;
+        LoaderBackend secondary = (primary == LoaderBackend::ImageMagick)
+            ? LoaderBackend::OpenCV : LoaderBackend::ImageMagick;
+        candidates[nb++] = primary;
+        candidates[nb++] = secondary;
+    }
 
-    if (has_backend(primary)) {
-        auto img = load_from_memory_with_backend(data, size, format, primary);
+    std::string combined;
+    int tried = 0;
+    for (int i = 0; i < nb; ++i) {
+        LoaderBackend b = candidates[i];
+        if (!has_backend(b)) continue;
+        last_error_.clear();
+        auto img = load_from_memory_with_backend(data, size, format, b);
         if (img) {
-            last_used_ = primary;
+            last_used_ = b;
             return img;
         }
-        std::string saved_err = last_error_;
-        if (has_backend(secondary)) {
-            last_error_.clear();
-            img = load_from_memory_with_backend(data, size, format, secondary);
-            if (img) {
-                last_used_ = secondary;
-                return img;
-            }
-            last_error_ = std::string(backend_name(primary)) + ": " + saved_err
-                + "; " + backend_name(secondary) + ": " + last_error_;
-        } else {
-            last_error_ = saved_err;
-        }
-        return nullptr;
+        if (!combined.empty()) combined += "; ";
+        combined += backend_name(b);
+        combined += ": ";
+        combined += last_error_;
+        ++tried;
     }
 
-    if (has_backend(secondary)) {
-        auto img = load_from_memory_with_backend(data, size, format, secondary);
-        if (img) last_used_ = secondary;
-        return img;
+    if (tried == 0) {
+        last_error_ = "No image loader backend is available";
+    } else {
+        last_error_ = std::move(combined);
     }
-
-    last_error_ = "No image loader backend is available";
     return nullptr;
 }
 
@@ -347,6 +368,8 @@ ImageLoader::load_with_backend(const std::string& path, LoaderBackend backend) {
             last_error_ = "ImageMagick backend not compiled in";
             return nullptr;
 #endif
+        case LoaderBackend::FFmpeg:
+            return load_via_ffmpeg(path);
     }
     return nullptr;
 }
@@ -365,6 +388,8 @@ ImageLoader::load_from_memory_with_backend(const uint8_t* data, size_t size,
             last_error_ = "ImageMagick backend not compiled in";
             return nullptr;
 #endif
+        case LoaderBackend::FFmpeg:
+            return load_via_ffmpeg_memory(data, size, format);
     }
     return nullptr;
 }
@@ -517,5 +542,81 @@ bool ImageLoader::is_raw_format(const std::string& path) {
 bool ImageLoader::is_raw_format(SourceFormat format) {
     return format == SourceFormat::RAW;
 }
+
+bool ImageLoader::is_heif_family(const std::string& path) {
+    auto dot = path.rfind('.');
+    if (dot == std::string::npos) return false;
+    std::string ext = path.substr(dot);
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+    return ext == ".heic" || ext == ".heif" || ext == ".hif" || ext == ".avif";
+}
+
+bool ImageLoader::is_heif_family(SourceFormat format) {
+    return format == SourceFormat::HEIF || format == SourceFormat::AVIF;
+}
+
+// ---- FFmpeg path / memory ----
+//
+// The actual decoder lives in detail/ffmpeg_image_loader.* and is
+// pulled in only when IDIFF_HAVE_FFMPEG_IMAGE_DECODE is on.  The stub
+// path keeps the binary linkable (and produces a clear error) for
+// builds without FFmpeg.
+
+#ifdef IDIFF_HAVE_FFMPEG_IMAGE_DECODE
+
+std::unique_ptr<Image> ImageLoader::load_via_ffmpeg(const std::string& path) {
+    try {
+        auto buf = platform::read_file_binary(path);
+        if (buf.empty()) {
+            last_error_ = "Failed to read file: " + path;
+            return nullptr;
+        }
+        SourceFormat fmt = extension_to_format(path);
+        auto image = load_heif_avif_from_memory(
+            buf.data(), buf.size(), fmt, flags_, last_error_);
+        if (image) {
+            // load_heif_avif_from_memory does not know the on-disk
+            // path, so it falls back to whatever caller-supplied
+            // SourceFormat we passed -- but if extension_to_format
+            // returned Unknown we still want the field set to the
+            // detected format so the UI shows a useful label.
+            if (image->internal().info.source_format == SourceFormat::Unknown) {
+                image->internal().info.source_format = fmt;
+            }
+        }
+        return image;
+    } catch (const std::exception& e) {
+        last_error_ = std::string("FFmpeg: ") + e.what();
+        return nullptr;
+    }
+}
+
+std::unique_ptr<Image>
+ImageLoader::load_via_ffmpeg_memory(const uint8_t* data, size_t size,
+                                     SourceFormat format) {
+    try {
+        return load_heif_avif_from_memory(
+            data, size, format, flags_, last_error_);
+    } catch (const std::exception& e) {
+        last_error_ = std::string("FFmpeg: ") + e.what();
+        return nullptr;
+    }
+}
+
+#else
+
+std::unique_ptr<Image> ImageLoader::load_via_ffmpeg(const std::string& /*path*/) {
+    last_error_ = "FFmpeg image backend not compiled in";
+    return nullptr;
+}
+
+std::unique_ptr<Image>
+ImageLoader::load_via_ffmpeg_memory(const uint8_t* /*data*/, size_t /*size*/,
+                                     SourceFormat /*format*/) {
+    last_error_ = "FFmpeg image backend not compiled in";
+    return nullptr;
+}
+
+#endif // IDIFF_HAVE_FFMPEG_IMAGE_DECODE
 
 } // namespace idiff

--- a/src/core/image_loader.h
+++ b/src/core/image_loader.h
@@ -25,14 +25,16 @@ inline bool operator&(LoadFlag a, LoadFlag b) {
     return (static_cast<uint32_t>(a) & static_cast<uint32_t>(b)) != 0;
 }
 
-// Which decoder library to use for general (non-RAW) images.  Both
-// backends may be compiled into the same binary; ImageMagick is preferred
-// when available because it handles ICC profiles and a wider set of
-// formats, while OpenCV imgcodecs is always present and serves as the
-// fallback.
+// Which decoder library to use for general (non-RAW) images.  Multiple
+// backends may be compiled into the same binary; for HEIF/AVIF the
+// preferred order is FFmpeg -> ImageMagick -> OpenCV, while the
+// existing PNG/JPEG/WebP/TIFF/BMP path uses ImageMagick -> OpenCV.
+// load() transparently falls back to the next available backend if
+// the preferred one fails.
 enum class LoaderBackend {
     ImageMagick,  // Magick++; only available when built with IDIFF_HAVE_MAGICK
     OpenCV,       // opencv_imgcodecs; always available
+    FFmpeg,       // libav* HEIF/AVIF path; built when IDIFF_HAVE_FFMPEG_IMAGE_DECODE
 };
 
 class ImageLoader {
@@ -82,10 +84,19 @@ private:
     std::unique_ptr<Image> load_via_magick_memory(const uint8_t* data, size_t size,
                                                   SourceFormat format);
 #endif
+    std::unique_ptr<Image> load_via_ffmpeg(const std::string& path);
+    std::unique_ptr<Image> load_via_ffmpeg_memory(const uint8_t* data, size_t size,
+                                                  SourceFormat format);
     std::unique_ptr<Image> load_via_raw(const std::string& path);
 
     static bool is_raw_format(const std::string& path);
     static bool is_raw_format(SourceFormat format);
+
+    // True for the HEIF / AVIF family.  Used by load() to pick the
+    // FFmpeg-first backend order; everything else stays on the
+    // ImageMagick-first order.
+    static bool is_heif_family(const std::string& path);
+    static bool is_heif_family(SourceFormat format);
 };
 
 } // namespace idiff

--- a/src/core/media_source.cpp
+++ b/src/core/media_source.cpp
@@ -27,6 +27,8 @@ const char* source_format_name(SourceFormat f) noexcept {
         case SourceFormat::TIFF: return "TIFF";
         case SourceFormat::BMP:  return "BMP";
         case SourceFormat::RAW:  return "RAW";
+        case SourceFormat::HEIF: return "HEIF";
+        case SourceFormat::AVIF: return "AVIF";
         default:                 return "Unknown";
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -128,3 +128,31 @@ if(IDIFF_HAVE_FFMPEG)
         )
     endif()
 endif()
+
+# --- HEIF / AVIF sample paths ---
+#
+# The image_loader tests below need optional HEIF / AVIF inputs to
+# exercise the FFmpeg-backed decoding path.  Sample paths are passed
+# in via compile definitions so the tests can SKIP cleanly when the
+# files are absent (CI runners without the samples installed, fresh
+# clones without git-lfs, etc.).
+#
+# Search order:
+#   1. tests/data/<name> in the repo (preferred -- co-located, easy
+#      to ship via git-lfs)
+#   2. fall back to a developer's home/Downloads sample
+set(_idiff_heif_tile_local
+    "${CMAKE_SOURCE_DIR}/tests/data/heif-tile.heif")
+set(_idiff_heif_tile_fallback
+    "$ENV{USERPROFILE}/Downloads/heif-tile.heif")
+
+if(EXISTS "${_idiff_heif_tile_local}")
+    set(_idiff_heif_tile_path "${_idiff_heif_tile_local}")
+elseif(EXISTS "${_idiff_heif_tile_fallback}")
+    set(_idiff_heif_tile_path "${_idiff_heif_tile_fallback}")
+else()
+    set(_idiff_heif_tile_path "")
+endif()
+
+target_compile_definitions(idiff_tests PRIVATE
+    IDIFF_TEST_HEIF_TILE_PATH="${_idiff_heif_tile_path}")

--- a/tests/test_image_loader.cpp
+++ b/tests/test_image_loader.cpp
@@ -223,3 +223,61 @@ TEST_CASE("ImageLoader::load accepts backslash Windows paths with CJK",
     std::filesystem::remove_all(dir);
 }
 #endif
+
+// -----------------------------------------------------------------------------
+// HEIF / AVIF FFmpeg backend
+// -----------------------------------------------------------------------------
+//
+// These cases need real sample files; without them they SKIP rather
+// than fail.  IDIFF_TEST_HEIF_TILE_PATH is set by tests/CMakeLists.txt
+// to either tests/data/heif-tile.heif or the developer's
+// ~/Downloads/heif-tile.heif when present.
+
+#if defined(IDIFF_HAVE_FFMPEG_IMAGE_DECODE)
+
+namespace {
+
+bool sample_exists(const char* path) {
+    return path && *path != '\0' &&
+           std::filesystem::exists(std::filesystem::u8path(path));
+}
+
+}  // namespace
+
+TEST_CASE("ImageLoader: FFmpeg backend is reported as compiled in",
+          "[image_loader][heif]") {
+    REQUIRE(ImageLoader::has_backend(LoaderBackend::FFmpeg));
+    REQUIRE(std::string(ImageLoader::backend_name(LoaderBackend::FFmpeg))
+            == "FFmpeg");
+}
+
+TEST_CASE("ImageLoader: opens a multi-tile HEIF grid as a single full image",
+          "[image_loader][heif][grid]") {
+    if (!sample_exists(IDIFF_TEST_HEIF_TILE_PATH)) {
+        SKIP("HEIF tile sample not available "
+             "(IDIFF_TEST_HEIF_TILE_PATH is empty)");
+    }
+
+    ImageLoader loader;
+    auto img = loader.load(IDIFF_TEST_HEIF_TILE_PATH);
+    REQUIRE(img != nullptr);
+    REQUIRE(loader.last_used_backend() == LoaderBackend::FFmpeg);
+
+    const auto& info = img->info();
+
+    // HEIF grids -- like the sample at hand -- are usually composed
+    // from many 512x512 tiles.  The whole point of tile-grid support
+    // is that the loader returns ONE composed image, not one tile, so
+    // the reported dimensions must be strictly larger than a single
+    // tile.  We don't pin exact W/H because the sample may change.
+    REQUIRE(info.width  > 512);
+    REQUIRE(info.height > 512);
+
+    // Pixel data must be present and match the reported shape.
+    REQUIRE(img->mat().cols == info.width);
+    REQUIRE(img->mat().rows == info.height);
+
+    REQUIRE(info.source_format == SourceFormat::HEIF);
+}
+
+#endif  // IDIFF_HAVE_FFMPEG_IMAGE_DECODE


### PR DESCRIPTION
The HEIF and AVIF families used to be readable only when ImageMagick was both installed and built with the matching delegates, which is unreliable on Windows and vcpkg setups. This change adds a third image-decoding backend driven by libavformat, libavcodec, and libavfilter (already linked for video) so .heic, .heif, .hif, and .avif files open natively without any new third-party dependency.

Multi-tile grids are composed in-process: the decoder produces one frame per tile, and an xstack-based filter graph assembles them onto the canvas described by the file's tile-grid metadata, then crops to the presentation dimensions. Single-tile main images skip the graph entirely and go through the standard frame-to-image path, with optional alpha, 16-bit output, and embedded ICC profile detection preserved.

The Image Loader menu now reflects this layout: the selectable rows still let the user pick the preferred decoder for general formats (PNG, JPEG, etc.), and a separate read-only row shows that HEIF and AVIF files are always tried with FFmpeg first and fall back to ImageMagick or OpenCV automatically. A tooltip explains the split so the menu is no longer ambiguous about what the choice affects.

CMake autodetects the new path: when FFmpeg 8.0 or newer is found, the build prints which decoder will handle HEIF and AVIF. No new packages need to be installed.

Closes #7