### PR TITLE
Fix wrong colors when loading HDR/wide-gamut HEIF images

### DIFF
--- a/src/core/detail/ffmpeg_image_loader.cpp
+++ b/src/core/detail/ffmpeg_image_loader.cpp
@@ -5,6 +5,8 @@
 #include "core/detail/heif_tile_assembler.h"
 #include "core/image_impl.h"
 #include "core/image_loader.h"  // for LoadFlag
+#include "core/video_decoder.h"        // for VideoColorTags
+#include "core/video_filter_graph.h"   // for VideoFilterGraph
 #include "util/logger.h"
 
 extern "C" {
@@ -15,7 +17,6 @@ extern "C" {
 #include <libavutil/imgutils.h>
 #include <libavutil/mem.h>
 #include <libavutil/pixdesc.h>
-#include <libswscale/swscale.h>
 }
 
 #include <opencv2/core.hpp>
@@ -134,13 +135,6 @@ struct AVFrameDeleter {
 };
 using AVFramePtr = std::unique_ptr<AVFrame, AVFrameDeleter>;
 
-struct SwsContextDeleter {
-    void operator()(SwsContext* sws) const noexcept {
-        if (sws) sws_freeContext(sws);
-    }
-};
-using SwsContextPtr = std::unique_ptr<SwsContext, SwsContextDeleter>;
-
 // ============================================================================
 // Single-stream decode
 // ============================================================================
@@ -237,6 +231,39 @@ AVFramePtr decode_one_frame(AVFormatContext* fmt_ctx,
 // AVFrame -> Image (RGB(A) 8 / 16-bit)
 // ============================================================================
 
+// Human-readable color-space label derived from the source frame's
+// (already resolved) color tags.  Informational only -- shown in the
+// UI / metadata panel.  The decoded pixels are always converted to
+// display sRGB downstream, so this string describes the *source*, not
+// the stored buffer.
+std::string describe_color_space(const VideoColorTags& tags, int w, int h) {
+    const AVColorPrimaries prim = tags.resolved_primaries(w, h);
+    const AVColorTransferCharacteristic trc = tags.resolved_transfer(w, h);
+
+    const char* gamut = nullptr;
+    switch (prim) {
+        case AVCOL_PRI_BT709:    gamut = "BT.709";    break;
+        case AVCOL_PRI_BT2020:   gamut = "BT.2020";   break;
+        case AVCOL_PRI_SMPTE432: gamut = "Display P3"; break;
+        case AVCOL_PRI_BT470BG:  gamut = "BT.601";    break;
+        case AVCOL_PRI_SMPTE170M:gamut = "BT.601";    break;
+        default:                 gamut = nullptr;     break;
+    }
+
+    const char* transfer = nullptr;
+    switch (trc) {
+        case AVCOL_TRC_SMPTE2084:   transfer = "PQ";  break;
+        case AVCOL_TRC_ARIB_STD_B67:transfer = "HLG"; break;
+        default:                    transfer = nullptr; break;
+    }
+
+    if (gamut && transfer) return std::string(gamut) + " " + transfer;
+    if (gamut)             return gamut;
+
+    const char* name = av_color_primaries_name(prim);
+    return name ? name : "Unknown";
+}
+
 PixelFormat select_target_pixel_format(AVPixelFormat src,
                                        std::uint32_t flags,
                                        AVPixelFormat& out_av_fmt) {
@@ -293,41 +320,77 @@ bool avframe_to_image(AVFrame* frame,
                      target_fmt == PixelFormat::RGBA16) ? 16 : 8;
     int cv_type = (bit_depth == 16) ? CV_16UC(channels) : CV_8UC(channels);
 
-    cv::Mat mat(frame->height, frame->width, cv_type);
+    // Resolve the source color description, applying FFmpeg's
+    // SD/HD/UHD-HDR fallbacks for UNSPECIFIED tags -- the same
+    // resolution the video path uses (video_decoder.cpp).
+    VideoColorTags tags;
+    tags.range     = frame->color_range;
+    tags.matrix    = frame->colorspace;
+    tags.primaries = frame->color_primaries;
+    tags.transfer  = frame->color_trc;
+
+    // Convert YUV -> display RGB through vf_scale so the source
+    // matrix / primaries / transfer are honoured and PQ/HLG HDR is
+    // tone-mapped to sRGB.  A bare sws_getContext (the previous
+    // implementation) ignored all of this and produced wrong colors
+    // on HDR / BT.2020 sources.
+    VideoFilterInputParams in;
+    in.width     = frame->width;
+    in.height    = frame->height;
+    in.pix_fmt   = static_cast<AVPixelFormat>(frame->format);
+    in.sar       = (frame->sample_aspect_ratio.num &&
+                    frame->sample_aspect_ratio.den)
+                       ? frame->sample_aspect_ratio
+                       : AVRational{1, 1};
+    in.time_base = AVRational{1, 1};
+    in.range     = tags.resolved_range();
+    in.matrix    = tags.resolved_matrix(frame->width, frame->height);
+    in.primaries = tags.resolved_primaries(frame->width, frame->height);
+    in.transfer  = tags.resolved_transfer(frame->width, frame->height);
+
+    VideoFilterOutputParams out;
+    out.width     = 0;  // keep source size
+    out.height    = 0;
+    out.pix_fmt   = target_av_fmt;
+    out.range     = AVCOL_RANGE_JPEG;          // full range
+    out.matrix    = AVCOL_SPC_RGB;             // identity (RGB)
+    out.primaries = AVCOL_PRI_BT709;
+    out.transfer  = AVCOL_TRC_IEC61966_2_1;    // sRGB
+
+    VideoFilterGraph graph;
+    if (!graph.configure(in, out, err)) {
+        return false;
+    }
+
+    AVFramePtr converted(graph.process(frame, err));
+    if (!converted) {
+        return false;
+    }
+
+    cv::Mat mat(converted->height, converted->width, cv_type);
     if (mat.empty()) {
         err = "cv::Mat allocation failed";
         return false;
     }
 
-    SwsContextPtr sws(sws_getContext(
-        frame->width, frame->height,
-        static_cast<AVPixelFormat>(frame->format),
-        frame->width, frame->height,
-        target_av_fmt,
-        SWS_BILINEAR, nullptr, nullptr, nullptr));
-    if (!sws) {
-        err = "sws_getContext failed";
-        return false;
-    }
-
-    uint8_t* dst_data[4]   = {mat.ptr(), nullptr, nullptr, nullptr};
-    int      dst_strides[4] = {static_cast<int>(mat.step[0]), 0, 0, 0};
-    int rc = sws_scale(sws.get(),
-                       frame->data, frame->linesize,
-                       0, frame->height,
-                       dst_data, dst_strides);
-    if (rc <= 0) {
-        err = "sws_scale produced no output";
-        return false;
+    // Copy row by row: the filter output linesize may include padding.
+    const size_t row_bytes =
+        static_cast<size_t>(converted->width) * channels *
+        (bit_depth == 16 ? 2 : 1);
+    for (int y = 0; y < converted->height; ++y) {
+        std::memcpy(mat.ptr(y),
+                    converted->data[0] + y * converted->linesize[0],
+                    row_bytes);
     }
 
     auto& impl = image.internal();
-    impl.info.width            = frame->width;
-    impl.info.height           = frame->height;
+    impl.info.width            = converted->width;
+    impl.info.height           = converted->height;
     impl.info.pixel_format     = target_fmt;
     impl.info.bit_depth        = bit_depth;
     impl.info.has_alpha        = (channels == 4);
-    impl.info.color_space      = "sRGB";
+    impl.info.color_space =
+        describe_color_space(tags, frame->width, frame->height);
     impl.info.source_format    = src_format;
 
     // Record the source bit depth so the UI can show "10-bit AVIF"
@@ -449,6 +512,23 @@ std::unique_ptr<Image> decode_tile_grid(AVFormatContext* fmt_ctx,
         tile_frames.push_back(std::move(frame));
     }
 
+    // All tiles share one source color description; resolve it once
+    // from the first tile (applying SD/HD/UHD-HDR fallbacks) and pass
+    // it to every input so the composed frame carries correct tags.
+    AVFrame* ref = tile_frames[0].get();
+    VideoColorTags tags;
+    tags.range     = ref->color_range;
+    tags.matrix    = ref->colorspace;
+    tags.primaries = ref->color_primaries;
+    tags.transfer  = ref->color_trc;
+    const AVColorRange res_range     = tags.resolved_range();
+    const AVColorSpace res_matrix    = tags.resolved_matrix(ref->width,
+                                                            ref->height);
+    const AVColorPrimaries res_prim  = tags.resolved_primaries(ref->width,
+                                                               ref->height);
+    const AVColorTransferCharacteristic res_trc =
+        tags.resolved_transfer(ref->width, ref->height);
+
     // ---- build assembler ----
     HeifTileAssembler assembler;
     std::vector<HeifTileInputDesc> inputs;
@@ -465,13 +545,20 @@ std::unique_ptr<Image> decode_tile_grid(AVFormatContext* fmt_ctx,
         // HEIF stills have no real timebase; xstack only requires that
         // every input shares one, so {1,1} on every src is fine.
         d.time_base = AVRational{1, 1};
+        d.range     = res_range;
+        d.matrix    = res_matrix;
+        d.primaries = res_prim;
+        d.transfer  = res_trc;
         inputs.push_back(d);
     }
 
-    // Pick sink pix_fmt based on caller flags.
-    AVPixelFormat sink_av_fmt = AV_PIX_FMT_NONE;
-    select_target_pixel_format(
-        static_cast<AVPixelFormat>(tile_frames[0]->format), flags, sink_av_fmt);
+    // Compose in the tiles' native pixel format so the source color
+    // space is preserved.  The composed frame carries the source color
+    // tags and is converted to display RGB by avframe_to_image's
+    // VideoFilterGraph pass -- identical color handling to the
+    // single-tile path.
+    const AVPixelFormat sink_av_fmt =
+        static_cast<AVPixelFormat>(ref->format);
 
     if (!assembler.configure(grid, inputs, sink_av_fmt, err)) {
         return nullptr;

--- a/src/core/detail/heif_tile_assembler.cpp
+++ b/src/core/detail/heif_tile_assembler.cpp
@@ -52,6 +52,13 @@ struct HeifTileAssembler::Impl {
     int coded_w = 0, coded_h = 0;
     int out_w = 0, out_h = 0;
 
+    // Source color tags (from inputs[0]) stamped onto the composed
+    // output frame so the downstream YUV->RGB pass honours them.
+    AVColorRange color_range = AVCOL_RANGE_UNSPECIFIED;
+    AVColorSpace color_matrix = AVCOL_SPC_UNSPECIFIED;
+    AVColorPrimaries color_primaries = AVCOL_PRI_UNSPECIFIED;
+    AVColorTransferCharacteristic color_trc = AVCOL_TRC_UNSPECIFIED;
+
     void close() noexcept {
         if (graph) {
             avfilter_graph_free(&graph);  // also frees src/sink ctxs
@@ -158,6 +165,19 @@ bool HeifTileAssembler::configure(const AVStreamGroupTileGrid* grid,
         rc |= av_opt_set_q(src, "time_base", tb, AV_OPT_SEARCH_CHILDREN);
         rc |= av_opt_set_q(src, "pixel_aspect", sar,
                            AV_OPT_SEARCH_CHILDREN);
+        // Color description: the `buffer` source only exposes
+        // `colorspace` (YUV matrix) and `range` as options; primaries
+        // and transfer are not settable here and instead travel on the
+        // pushed AVFrames (stamped in assemble()).  Only set fields the
+        // caller actually resolved.
+        if (d.range != AVCOL_RANGE_UNSPECIFIED) {
+            rc |= av_opt_set_int(src, "range", d.range,
+                                 AV_OPT_SEARCH_CHILDREN);
+        }
+        if (d.matrix != AVCOL_SPC_UNSPECIFIED) {
+            rc |= av_opt_set_int(src, "colorspace", d.matrix,
+                                 AV_OPT_SEARCH_CHILDREN);
+        }
         if (rc != 0) {
             err = "buffer src option set failed";
             impl_->close();
@@ -348,6 +368,10 @@ bool HeifTileAssembler::configure(const AVStreamGroupTileGrid* grid,
     impl_->nb_tiles = static_cast<int>(grid->nb_tiles);
     impl_->coded_w  = grid->coded_width;
     impl_->coded_h  = grid->coded_height;
+    impl_->color_range     = inputs[0].range;
+    impl_->color_matrix    = inputs[0].matrix;
+    impl_->color_primaries = inputs[0].primaries;
+    impl_->color_trc       = inputs[0].transfer;
     impl_->configured = true;
 
     LOG_INFO("HeifTileAssembler: configured %d tiles, "
@@ -383,6 +407,15 @@ AVFrame* HeifTileAssembler::assemble(const std::vector<AVFrame*>& tiles,
             err = buf;
             return nullptr;
         }
+        // Stamp the resolved source color tags onto the frame so the
+        // graph's auto-inserted scale node sees correct primaries and
+        // transfer (the buffer source only carries matrix + range).
+        // These are scalar metadata fields, not shared pixel buffers,
+        // so updating them under KEEP_REF is safe.
+        f->color_range     = impl_->color_range;
+        f->colorspace      = impl_->color_matrix;
+        f->color_primaries = impl_->color_primaries;
+        f->color_trc       = impl_->color_trc;
         if (int ret = av_buffersrc_add_frame_flags(
                 impl_->src_ctxs[i], f, AV_BUFFERSRC_FLAG_KEEP_REF);
             ret < 0) {
@@ -407,6 +440,14 @@ AVFrame* HeifTileAssembler::assemble(const std::vector<AVFrame*>& tiles,
         av_frame_free(&out);
         return nullptr;
     }
+
+    // Carry the source color tags onto the composed frame so the
+    // downstream VideoFilterGraph pass converts from the correct
+    // source color space.
+    out->color_range     = impl_->color_range;
+    out->colorspace      = impl_->color_matrix;
+    out->color_primaries = impl_->color_primaries;
+    out->color_trc       = impl_->color_trc;
 
     LOG_DEBUG("HeifTileAssembler: assembled %d tiles "
               "(canvas %dx%d -> output %dx%d)",

--- a/src/core/detail/heif_tile_assembler.h
+++ b/src/core/detail/heif_tile_assembler.h
@@ -27,6 +27,17 @@ struct HeifTileInputDesc {
     AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
     AVRational sar{1, 1};
     AVRational time_base{1, 1};
+
+    // Source color description.  All tiles of one HEIF image share a
+    // single description; it is set on every buffer source so the
+    // graph interprets chroma correctly, and stamped onto the composed
+    // output frame so the downstream YUV->RGB conversion can honour
+    // the source matrix / primaries / transfer.  Defaults are the
+    // FFmpeg UNSPECIFIED sentinels.
+    AVColorRange range = AVCOL_RANGE_UNSPECIFIED;
+    AVColorSpace matrix = AVCOL_SPC_UNSPECIFIED;
+    AVColorPrimaries primaries = AVCOL_PRI_UNSPECIFIED;
+    AVColorTransferCharacteristic transfer = AVCOL_TRC_UNSPECIFIED;
 };
 
 // Wrapper around a one-shot HEIF tile-grid composition graph:
@@ -68,11 +79,13 @@ public:
     HeifTileAssembler& operator=(HeifTileAssembler&&) = delete;
 
     // Build the graph for a particular grid.  `out_pix_fmt` is the
-    // pixel format the buffersink is constrained to; the caller
-    // should pick a packed RGB(A) format compatible with the rest
-    // of idiff's image pipeline (RGB24 / RGBA / RGB48LE / RGBA64LE).
-    // Returns true on success; on failure, fills `err` and leaves
-    // the assembler in a closed state.
+    // pixel format the buffersink is constrained to.  Callers that
+    // want correct color handling should pass the tiles' *native*
+    // pixel format here so composition stays in the source color
+    // space; the composed output frame carries the source color tags
+    // (from inputs[0]) and is converted to display RGB by a later
+    // VideoFilterGraph pass.  Returns true on success; on failure,
+    // fills `err` and leaves the assembler in a closed state.
     bool configure(const AVStreamGroupTileGrid* grid,
                    const std::vector<HeifTileInputDesc>& inputs,
                    AVPixelFormat out_pix_fmt,

--- a/src/core/video_filter_graph.cpp
+++ b/src/core/video_filter_graph.cpp
@@ -271,9 +271,17 @@ bool VideoFilterGraph::configure(const VideoFilterInputParams& in,
     // format -- explicitly setting out_color_matrix=RGB on packed
     // RGB outputs makes vf_scale apply an unwanted second matrix
     // step.  For YUV / gray destinations we do need to tell vf_scale
-    // which matrix to encode into.
-    const bool out_is_packed_rgb = (out.pix_fmt == AV_PIX_FMT_RGB24 ||
-                                    out.pix_fmt == AV_PIX_FMT_BGR24);
+    // which matrix to encode into.  Detect from the pixel descriptor:
+    // RGB colour model (AV_PIX_FMT_FLAG_RGB) and packed layout (PLANAR
+    // not set).  FLAG_RGB alone is not enough -- GBRP / GBRAP are
+    // planar RGB and must not be treated as a packed-RGB sink.  This
+    // covers every packed RGB sink the loader reuses (RGB24, RGBA,
+    // RGB48, RGBA64) without enumerating formats by hand.
+    const AVPixFmtDescriptor* out_desc = av_pix_fmt_desc_get(out.pix_fmt);
+    const bool out_is_packed_rgb =
+        out_desc &&
+        (out_desc->flags & AV_PIX_FMT_FLAG_RGB) &&
+        !(out_desc->flags & AV_PIX_FMT_FLAG_PLANAR);
 
     rc = 0;
     rc |= av_opt_set    (scale_ctx, "w", wbuf, AV_OPT_SEARCH_CHILDREN);


### PR DESCRIPTION
The FFmpeg still-image HEIF/AVIF loader converted decoded YUV to RGB with a bare sws_getContext() that received only the pixel format and dimensions. With no range, matrix, primaries, or transfer information, swscale fell back to BT.601 defaults and ignored the source transfer function, so a 10-bit BT.2020 HEIC decoded with the wrong matrix and no gamut handling and displayed visibly wrong colors. The color_space field was also hard-coded to "sRGB".

Route the still-image path through the same VideoFilterGraph the video decoder already uses: read the source color tags from the decoded frame, resolve UNSPECIFIED values with FFmpeg's SD/HD/UHD fallbacks, and convert to display sRGB (BT.709 primaries, sRGB transfer, full range). The reported color_space string now reflects the real source description instead of a fixed label.

For multi-tile HEIF, compose the tiles in their native pixel format so the source color description survives, propagate the color tags onto the buffer sources and the composed frame, and convert through the same VideoFilterGraph pass. Single-tile and multi-tile images now share one color path.

Detect packed-RGB sinks in VideoFilterGraph from the pixel descriptor (RGB color model, non-planar) instead of matching RGB24/BGR24 by hand, so the 16-bit and alpha sinks the loader reuses (RGB48, RGBA, RGBA64) do not get an unwanted second matrix step.

Convert the three detail/ source files from CRLF to LF line endings to match the rest of the tree.