### PR TITLE
Fix SAR-stretched hover coordinates indexing source pixels

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1606,33 +1606,39 @@ void App::update_pixel_inspector_hover() {
     int px = vp->hover_pixel_x();
     int py = vp->hover_pixel_y();
 
-    const cv::Mat* mat = nullptr;
+    const Image* src_img = nullptr;
+    // Diff heatmaps are already at display resolution, so their mat
+    // dims are the correct normalizer.  Every other mode passes 0/0
+    // to let hover_pixel_to_norm pick the image's display_width/height.
+    int override_disp_w = 0;
+    int override_disp_h = 0;
 
     if (vp->mode() == ComparisonMode::Difference) {
         if (diff_service_ && cell >= 0 &&
             cell < static_cast<int>(diff_service_->size())) {
             const auto& slot = diff_service_->slots()[cell];
-            if (slot.image) mat = &slot.image->mat();
+            src_img = slot.image.get();
+            if (src_img && !src_img->mat().empty()) {
+                override_disp_w = src_img->mat().cols;
+                override_disp_h = src_img->mat().rows;
+            }
         }
     } else if (cell >= 0 &&
                cell < static_cast<int>(viewport_slot_to_entry_.size())) {
         int ent = viewport_slot_to_entry_[cell];
         if (ent >= 0 && ent < static_cast<int>(entries_view().size())) {
             const auto& e = entries_view()[ent];
-            if (e.image) mat = &e.image->mat();
+            src_img = e.image.get();
         }
     }
 
-    if (!mat || mat->empty() ||
-        px < 0 || py < 0 ||
-        px >= mat->cols || py >= mat->rows) {
+    HoverNorm hn = hover_pixel_to_norm(src_img, px, py,
+                                       override_disp_w, override_disp_h);
+    if (!hn.valid) {
         state_->pixel_panel->update_hover(0.0, 0.0, false);
         return;
     }
-
-    double u = pixel_to_norm(px, mat->cols);
-    double v = pixel_to_norm(py, mat->rows);
-    state_->pixel_panel->update_hover(u, v, true);
+    state_->pixel_panel->update_hover(hn.u, hn.v, true);
 }
 
 void App::render_error_dialog() {

--- a/src/app/pixel_sampler.cpp
+++ b/src/app/pixel_sampler.cpp
@@ -294,6 +294,23 @@ int norm_to_pixel(double u, int w) {
     return px;
 }
 
+HoverNorm hover_pixel_to_norm(const Image* img,
+                              int px, int py,
+                              int disp_w, int disp_h) {
+    HoverNorm out;
+    if (!img) return out;
+    const cv::Mat& m = img->mat();
+    if (m.empty()) return out;
+    if (disp_w <= 0) disp_w = img->info().display_width();
+    if (disp_h <= 0) disp_h = img->info().display_height();
+    if (disp_w <= 0 || disp_h <= 0) return out;
+    if (px < 0 || py < 0 || px >= disp_w || py >= disp_h) return out;
+    out.u = pixel_to_norm(px, disp_w);
+    out.v = pixel_to_norm(py, disp_h);
+    out.valid = true;
+    return out;
+}
+
 bool format_pixel(const PixelSample& s, char* buf, std::size_t n) {
     if (n == 0) return false;
     if (!s.valid) {

--- a/src/app/pixel_sampler.h
+++ b/src/app/pixel_sampler.h
@@ -75,6 +75,30 @@ double pixel_to_norm(int x, int w);
 // w <= 0 returns 0.
 int norm_to_pixel(double u, int w);
 
+// Convert a viewport hover pixel (px, py), reported in the image's
+// display (SAR-adjusted) coordinate system, into normalized (u, v)
+// suitable for sample_image_at().  Uses display_width()/display_height()
+// so the result stays valid when SAR != 1:1 -- normalizing against the
+// source mat's cols/rows instead would shrink the valid range and shift
+// the sampled pixel whenever the viewport upscaled the image for
+// aspect-correct display.
+//
+// `disp_w`/`disp_h` let the caller override the display dimensions for
+// paths that already produce display-resolution data (e.g. the diff
+// heatmap, whose mat dims equal its display dims).  Pass 0/0 to use the
+// image's own display_width()/display_height().
+//
+// Returns valid=false when img is null, has no pixel data, or (px, py)
+// falls outside [0, disp_w) x [0, disp_h).
+struct HoverNorm {
+    double u = 0.0;
+    double v = 0.0;
+    bool valid = false;
+};
+HoverNorm hover_pixel_to_norm(const Image* img,
+                              int px, int py,
+                              int disp_w = 0, int disp_h = 0);
+
 // Render a PixelSample as text suitable for the inspector table.
 // Returns true on success.  Unsupported depths produce
 // "(unsupported depth)" and return false; the buffer is always

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -124,6 +124,12 @@ void render_status_bar(const StatusBarInputs& in) {
 
                 const char* src_label = nullptr;
                 const Image* src_img = nullptr;
+                // Diff heatmaps are already at display resolution, so
+                // their mat dims are the correct normalizer.  Every
+                // other mode passes 0/0 to let hover_pixel_to_norm pick
+                // the image's display_width/height.
+                int override_disp_w = 0;
+                int override_disp_h = 0;
 
                 if (vport.mode() == ComparisonMode::Difference) {
                     // Map the hovered cell back to its diff slot so
@@ -134,6 +140,10 @@ void render_status_bar(const StatusBarInputs& in) {
                         cell < static_cast<int>(diff_service.size())) {
                         const auto& slot = diff_service.slots()[cell];
                         src_img = slot.image.get();
+                        if (src_img && !src_img->mat().empty()) {
+                            override_disp_w = src_img->mat().cols;
+                            override_disp_h = src_img->mat().rows;
+                        }
                         static thread_local std::string diff_label;
                         std::string partner = "?";
                         if (slot.partner_entry_idx >= 0 &&
@@ -158,22 +168,28 @@ void render_status_bar(const StatusBarInputs& in) {
                     int ent = slot_to_entry[cell];
                     if (ent >= 0 && ent < static_cast<int>(entries.size())) {
                         const auto& e = entries[ent];
-                        // Hover px/py from the viewport are in the
-                        // source image's native coordinate system, so
-                        // read pixels from the original image rather
-                        // than display_image, which may be upscaled
-                        // with interpolated pixels.
+                        // Sample from the original image rather than
+                        // display_image, which may be upscaled with
+                        // interpolated pixels.
                         src_img = e.image.get();
                         src_label = e.display_label.c_str();
                     }
                 }
 
-                append(" | %s @ (%d, %d)", src_label ? src_label : "?", px, py);
-
-                if (src_img) {
+                HoverNorm hn = hover_pixel_to_norm(src_img, px, py,
+                                                   override_disp_w,
+                                                   override_disp_h);
+                if (hn.valid) {
                     const auto& m = src_img->mat();
-                    if (!m.empty() &&
-                        px >= 0 && px < m.cols && py >= 0 && py < m.rows) {
+                    // Show source-native coordinates so the readout
+                    // matches the pixel inspector's (x, y) column and
+                    // stays within the source frame's bounds.
+                    int sx = (!m.empty()) ? norm_to_pixel(hn.u, m.cols) : px;
+                    int sy = (!m.empty()) ? norm_to_pixel(hn.v, m.rows) : py;
+                    append(" | %s @ (%d, %d)",
+                           src_label ? src_label : "?", sx, sy);
+
+                    if (!m.empty()) {
                         // Status bar always reflects what is on screen:
                         // the post-conversion 8-bit sRGB pixel.  Force
                         // the RGB path so the inspector's YUV/RGB
@@ -181,15 +197,15 @@ void render_status_bar(const StatusBarInputs& in) {
                         // of these numbers.  format_pixel adds the
                         // "R G B:" prefix so users no longer have to
                         // guess what (a, b, c) means.
-                        double u = pixel_to_norm(px, m.cols);
-                        double v = pixel_to_norm(py, m.rows);
-                        PixelSample s = sample_image_at(src_img, u, v,
+                        PixelSample s = sample_image_at(src_img, hn.u, hn.v,
                                                         /*prefer_rgb=*/true);
                         char vbuf[96];
                         if (s.valid && format_pixel(s, vbuf, sizeof(vbuf))) {
                             append(" = %s", vbuf);
                         }
                     }
+                } else if (src_label) {
+                    append(" | %s", src_label);
                 }
             }
 

--- a/tests/test_pixel_sampler.cpp
+++ b/tests/test_pixel_sampler.cpp
@@ -539,6 +539,111 @@ TEST_CASE("sample_image_at: prefer_rgb is a no-op when there is no AVFrame",
 }
 
 // -----------------------------------------------------------------------------
+// hover_pixel_to_norm: SAR-aware normalization regression.
+//
+// The viewport reports hover (px, py) in the image's display (SAR-
+// adjusted) coordinate system.  Normalizing against the source mat's
+// cols/rows instead of display_width/height shrinks the valid range
+// and shifts the sampled pixel whenever SAR != 1:1.  This case
+// reproduces the original bug report: a 720x576 PAL video with SAR
+// 64:45 (display 1024x576) whose bottom-right hover reported (1023,
+// 575) and either went out-of-range or sampled a shifted pixel.
+// -----------------------------------------------------------------------------
+
+namespace {
+
+Image make_sar_image(int w, int h, int sar_num, int sar_den) {
+    Image img;
+    img.internal().mat = cv::Mat(h, w, CV_8UC3, cv::Scalar(0, 0, 0));
+    img.internal().info.width = w;
+    img.internal().info.height = h;
+    img.internal().info.sar_num = sar_num;
+    img.internal().info.sar_den = sar_den;
+    return img;
+}
+
+} // namespace
+
+TEST_CASE("hover_pixel_to_norm: uses display dimensions, not source",
+          "[pixel_sampler][sar]") {
+    // 720x576 with SAR 64:45 -> display 1024x576 (PAL 16:9).
+    Image img = make_sar_image(/*w=*/720, /*h=*/576,
+                               /*sar_num=*/64, /*sar_den=*/45);
+    REQUIRE(img.info().display_width() == 1024);
+    REQUIRE(img.info().display_height() == 576);
+
+    SECTION("display-space corner maps to the expected normalized coord") {
+        // Bottom-right of the *display* rect is (1023, 575).  This is
+        // the exact hover that used to report "@ (1023, 575)" and then
+        // fail the px < mat->cols (1023 < 720) bounds check in the
+        // pixel inspector.  It must now be valid and normalize against
+        // 1024/576.
+        HoverNorm hn = hover_pixel_to_norm(&img, 1023, 575);
+        REQUIRE(hn.valid);
+        REQUIRE(hn.u == Catch::Approx(pixel_to_norm(1023, 1024)));
+        REQUIRE(hn.v == Catch::Approx(pixel_to_norm(575, 576)));
+    }
+
+    SECTION("display-space center samples the source-frame center") {
+        // Display center (512, 288) should map back to source pixel
+        // (360, 288) -- the source center.  Pre-fix the helper would
+        // have computed u = pixel_to_norm(512, 720), placing the
+        // sample near the right edge of the source instead of the
+        // middle.
+        HoverNorm hn = hover_pixel_to_norm(&img, 512, 288);
+        REQUIRE(hn.valid);
+        int src_x = norm_to_pixel(hn.u, 720);
+        int src_y = norm_to_pixel(hn.v, 576);
+        REQUIRE(src_x == 360);
+        REQUIRE(src_y == 288);
+    }
+
+    SECTION("hover at display width is rejected (half-open interval)") {
+        // px == display_width is one past the last display column and
+        // must be invalid rather than silently clamped.
+        REQUIRE_FALSE(hover_pixel_to_norm(&img, 1024, 0).valid);
+        REQUIRE_FALSE(hover_pixel_to_norm(&img, 0, 576).valid);
+    }
+
+    SECTION("negative hover is rejected") {
+        REQUIRE_FALSE(hover_pixel_to_norm(&img, -1, 0).valid);
+        REQUIRE_FALSE(hover_pixel_to_norm(&img, 0, -1).valid);
+    }
+
+    SECTION("SAR 1:1 falls back to source dimensions") {
+        // No SAR: display dims equal source dims, so the helper must
+        // accept every (px, py) in [0, w) x [0, h).
+        Image plain = make_sar_image(8, 4, /*sar_num=*/0, /*sar_den=*/0);
+        REQUIRE(plain.info().display_width() == 8);
+        REQUIRE(plain.info().display_height() == 4);
+        REQUIRE(hover_pixel_to_norm(&plain, 0, 0).valid);
+        REQUIRE(hover_pixel_to_norm(&plain, 7, 3).valid);
+        REQUIRE_FALSE(hover_pixel_to_norm(&plain, 8, 0).valid);
+        REQUIRE_FALSE(hover_pixel_to_norm(&plain, 0, 4).valid);
+    }
+
+    SECTION("explicit disp_w/disp_h override the image's display dims") {
+        // Mirrors the diff-heatmap path: the caller passes mat dims
+        // directly because the heatmap is already at display resolution.
+        Image plain = make_sar_image(16, 16, 0, 0);
+        HoverNorm hn = hover_pixel_to_norm(&plain, 9, 9,
+                                           /*disp_w=*/10, /*disp_h=*/10);
+        REQUIRE(hn.valid);
+        REQUIRE(hn.u == Catch::Approx(pixel_to_norm(9, 10)));
+        REQUIRE(hn.v == Catch::Approx(pixel_to_norm(9, 10)));
+        // The override is what bounds the hover, not the image dims.
+        REQUIRE_FALSE(hover_pixel_to_norm(&plain, 10, 0,
+                                          /*disp_w=*/10, /*disp_h=*/10).valid);
+    }
+
+    SECTION("null or empty image is invalid") {
+        REQUIRE_FALSE(hover_pixel_to_norm(nullptr, 0, 0).valid);
+        Image empty;
+        REQUIRE_FALSE(hover_pixel_to_norm(&empty, 0, 0).valid);
+    }
+}
+
+// -----------------------------------------------------------------------------
 // format_delta: RGB <-> RGBA bridge.
 //
 // Real-world trigger: a user lines up an RGB24 PNG against a PAL8


### PR DESCRIPTION
Viewport hover (px, py) is reported in the display (SAR-adjusted) coordinate system, but the pixel inspector and status bar normalized it against the source mat's cols/rows.  For anamorphic video this shrank the valid range and shifted the sampled pixel: a 720x576 PAL frame with SAR 64:45 (display 1024x576) reported its bottom-right hover as (1023, 575), failed the px < 720 bounds check, and dropped the inspector sample even though the cursor was on a valid pixel.

Normalize against display dimensions instead.  Extract the conversion into hover_pixel_to_norm() so both call sites share one tested path, with an override for the diff-heatmap path whose mat dims already equal display dims.  Add a regression test reproducing the original bug report (720x576 SAR 64:45) and covering the center-mapping, half-open interval, SAR 1:1 fallback, override, and null/empty cases.