### PR TITLE
Embed Windows manifest to fix MSVC link error LNK1220

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -58,6 +58,7 @@ elseif(WIN32)
     if(MSVC)
         target_link_options(idiff PRIVATE
             "/MANIFEST"
+            "/MANIFEST:EMBED"
             "/MANIFESTUAC:NO"
             "/MANIFESTINPUT:${CMAKE_CURRENT_SOURCE_DIR}/platform/idiff.manifest")
     endif()


### PR DESCRIPTION
MSVC linker requires /MANIFEST:EMBED when /MANIFESTINPUT is specified. Without it, linking fails with:
  LINK : fatal error LNK1220: 'MANIFESTINPUT' requires
  '/MANIFEST:EMBED' specification