### PR TITLE
Fix exit hang in FileWatcher kqueue teardown

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -589,6 +589,13 @@ void App::shutdown() {
     diff_service_ = nullptr;
     comparison_config_ = nullptr;
 
+    // Stop the file watcher here rather than in ~App().  The watcher
+    // holds open fds against the library's paths; releasing them in
+    // the explicit shutdown path keeps teardown predictable instead
+    // of leaving it for the implicit State destructor after main()
+    // returns and SDL is gone.
+    state_->file_watcher.reset();
+
     // Status reporter is borrowed by the controller, so it must be
     // released after the controller is gone.
     state_->status_reporter.reset();

--- a/src/core/file_watcher.cpp
+++ b/src/core/file_watcher.cpp
@@ -103,10 +103,17 @@ struct FileWatcher::Impl {
         wake();
         if (thread_.joinable()) thread_.join();
 
+        // Deregister every watched fd before closing it (see
+        // deregister_and_close).  Then close the kqueue itself so
+        // any lingering kernel state is gone before the watched fds
+        // are released.
         for (auto& [path, fd] : watched_) {
-            close(fd);
+            deregister_and_close(fd);
         }
-        if (kq_ >= 0) close(kq_);
+        if (kq_ >= 0) {
+            close(kq_);
+            kq_ = -1;
+        }
         if (wake_pipe_[0] >= 0) close(wake_pipe_[0]);
         if (wake_pipe_[1] >= 0) close(wake_pipe_[1]);
     }
@@ -121,6 +128,22 @@ struct FileWatcher::Impl {
     void drain_wake_pipe() {
         char buf[64];
         while (read(wake_pipe_[0], buf, sizeof(buf)) > 0) {}
+    }
+
+    // Deregister a fd from the kqueue, then close it.  Closing a fd
+    // that is still on a kqueue forces the kernel to do synchronous
+    // teardown under the kqueue mutex, which can block for seconds
+    // when kernel cleanup work is pending.  EV_DELETE first makes the
+    // close a plain file-descriptor release.  Idempotent: kevent
+    // silently ignores EV_DELETE for filters that are not registered.
+    void deregister_and_close(int fd) {
+        if (fd < 0) return;
+        if (kq_ >= 0) {
+            struct kevent ev;
+            EV_SET(&ev, fd, EVFILT_VNODE, EV_DELETE, 0, 0, nullptr);
+            (void)kevent(kq_, &ev, 1, nullptr, 0, nullptr);
+        }
+        close(fd);
     }
 
     void add_path(const std::string& path) {
@@ -159,8 +182,7 @@ struct FileWatcher::Impl {
         if (it == watched_.end()) return;
 
         int fd = it->second;
-        // EV_DELETE is automatic when the fd is closed
-        close(fd);
+        deregister_and_close(fd);
         fd_to_path_.erase(fd);
         watched_.erase(it);
         changed_.erase(path);
@@ -170,7 +192,7 @@ struct FileWatcher::Impl {
     void clear() {
         std::lock_guard<std::mutex> lock(mutex_);
         for (auto& [path, fd] : watched_) {
-            close(fd);
+            deregister_and_close(fd);
         }
         watched_.clear();
         fd_to_path_.clear();
@@ -189,7 +211,7 @@ struct FileWatcher::Impl {
     // Caller must hold mutex_.  Takes path by value because the
     // caller passes a reference into fd_to_path_ which is erased below.
     void rewatch(std::string path, int old_fd) {
-        close(old_fd);
+        deregister_and_close(old_fd);
         fd_to_path_.erase(old_fd);
 
         int new_fd = open(path.c_str(), O_EVTONLY);


### PR DESCRIPTION
The macOS kqueue backend closed watched file descriptors while they were still registered on the kqueue.  close() on a fd with active kqueue filters forces the kernel to do synchronous teardown under the kqueue mutex, which blocks the main thread for seconds at exit when kernel cleanup work is pending.

Deregister each fd with EV_DELETE before closing it, then close the kqueue itself before closing the watched fds.  Apply the same ordering to clear(), remove_path(), and rewatch() via a shared deregister_and_close() helper.

Also reset state_->file_watcher inside App::shutdown() so the watcher is torn down in the explicit shutdown path rather than during ~App() after main() returns and SDL is gone.