### PR TITLE
Add timeline auto-playback for multi-frame comparison

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -636,6 +636,18 @@ void App::frame() {
     }
 #endif
 
+    // Auto-playback: advance the shared timeline index at the
+    // configured fps when playing.  Done before NewFrame so the UI
+    // already reflects the advanced index this iteration.  Wake the
+    // idle tracker so the main loop keeps rendering while playback
+    // is active.
+    if (timeline_ && timeline_length() > 1) {
+        if (timeline_->tick_playback(entries_view())) {
+            sync_entries_to_timeline();
+            if (idle_wake_fn_) idle_wake_fn_();
+        }
+    }
+
     ImGui_ImplSDLRenderer2_NewFrame();
     ImGui_ImplSDL2_NewFrame();
     ImGui::NewFrame();
@@ -656,6 +668,29 @@ void App::frame() {
             if (!entries_view().empty() &&
                 ImGui::IsKeyPressed(ImGuiKey_F5)) {
                 reload_all_images();
+            }
+
+            // Timeline playback / step shortcuts.  Space toggles
+            // play/pause; Left/Right step one frame.  Only active
+            // when at least one multi-frame source is loaded.
+            if (timeline_length() > 1) {
+                if (ImGui::IsKeyPressed(ImGuiKey_Space)) {
+                    timeline_->set_playing(!timeline_->playing());
+                }
+                if (ImGui::IsKeyPressed(ImGuiKey_LeftArrow)) {
+                    int f = timeline_->current_frame();
+                    if (f > 0) {
+                        timeline_->set_current_frame(f - 1);
+                        sync_entries_to_timeline();
+                    }
+                }
+                if (ImGui::IsKeyPressed(ImGuiKey_RightArrow)) {
+                    int f = timeline_->current_frame();
+                    if (f < timeline_length() - 1) {
+                        timeline_->set_current_frame(f + 1);
+                        sync_entries_to_timeline();
+                    }
+                }
             }
 
             // Channel view shortcuts: 1-9 cycle through modes.

--- a/src/app/ui/status_bar.cpp
+++ b/src/app/ui/status_bar.cpp
@@ -264,6 +264,12 @@ float render_timeline_bar(const TimelineBarInputs& in) {
             }
         }
         ImGui::SameLine();
+        // Play/Pause toggle.  Pausing on click also stops playback at
+        // the current frame rather than advancing.
+        if (ImGui::SmallButton(timeline.playing() ? "Pause" : "Play")) {
+            timeline.set_playing(!timeline.playing());
+        }
+        ImGui::SameLine();
         if (ImGui::SmallButton(">")) {
             if (timeline.current_frame() < length - 1) {
                 timeline.set_current_frame(timeline.current_frame() + 1);
@@ -287,6 +293,13 @@ float render_timeline_bar(const TimelineBarInputs& in) {
         }
         ImGui::SameLine();
         ImGui::Text("of %d", length);
+        ImGui::SameLine();
+        // Editable playback fps; clamped to [1, 120] by the model.
+        ImGui::SetNextItemWidth(60.0f);
+        double fps = timeline.playback_fps();
+        if (ImGui::InputDouble("fps", &fps, 0.0, 0.0, "%.0f")) {
+            timeline.set_playback_fps(fps);
+        }
 
         if (offset_rows > 0) {
             ImGui::BeginChild("##offsets",

--- a/src/domain/timeline_model.cpp
+++ b/src/domain/timeline_model.cpp
@@ -101,4 +101,27 @@ bool TimelineModel::clamp_to_length(const std::vector<ImageEntry>& entries) noex
     return true;
 }
 
+void TimelineModel::set_playback_fps(double fps) noexcept {
+    if (fps < 1.0) fps = 1.0;
+    if (fps > 120.0) fps = 120.0;
+    playback_fps_ = fps;
+}
+
+bool TimelineModel::tick_playback(
+    const std::vector<ImageEntry>& entries) noexcept {
+    if (!playing_) return false;
+    const int len = length(entries);
+    if (len <= 1) return false;
+    auto now = std::chrono::steady_clock::now();
+    if (now < next_frame_time_) return false;
+    int next = current_frame_ + 1;
+    if (next >= len) next = 0;  // loop
+    current_frame_ = next;
+    using double_sec = std::chrono::duration<double>;
+    auto interval = std::chrono::duration_cast<
+        std::chrono::steady_clock::duration>(double_sec(1.0 / playback_fps_));
+    next_frame_time_ = now + interval;
+    return true;
+}
+
 } // namespace idiff

--- a/src/domain/timeline_model.h
+++ b/src/domain/timeline_model.h
@@ -17,6 +17,7 @@
 //
 // Threading: not thread-safe; main thread only.
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -65,8 +66,38 @@ public:
     // lengths are coerced to length=1 -> current_frame_=0.
     bool clamp_to_length(const std::vector<ImageEntry>& entries) noexcept;
 
+    // ---- Playback -------------------------------------------------------
+    //
+    // Auto-play advances current_frame_ at a fixed fps driven by a
+    // steady-clock accumulator ticked once per App::frame().  At end
+    // the index loops back to 0.  The caller (App) is responsible
+    // for calling sync_entries_to_timeline() when tick_playback()
+    // reports an advance.
+
+    bool playing() const noexcept { return playing_; }
+    // Resetting to play re-arms next_frame_time_ to now so playback
+    // starts immediately rather than waiting for a stale deadline.
+    void set_playing(bool v) noexcept {
+        playing_ = v;
+        if (v) next_frame_time_ = std::chrono::steady_clock::now();
+    }
+    double playback_fps() const noexcept { return playback_fps_; }
+    // Clamp to [1, 120]; values outside that range are pinned.
+    void set_playback_fps(double fps) noexcept;
+
+    // Advance current_frame_ by one when the steady clock has passed
+    // next_frame_time_, looping back to 0 at length-1.  Returns true
+    // when a frame advance actually happened so the caller can call
+    // sync_to().  Returns false when playing is false, the clock has
+    // not yet reached the next frame time, or length(entries) <= 1.
+    bool tick_playback(const std::vector<ImageEntry>& entries) noexcept;
+
 private:
     int current_frame_ = 0;
+
+    bool playing_ = false;
+    double playback_fps_ = 30.0;
+    std::chrono::steady_clock::time_point next_frame_time_{};
 };
 
 } // namespace idiff

--- a/tests/test_timeline_model.cpp
+++ b/tests/test_timeline_model.cpp
@@ -248,3 +248,59 @@ TEST_CASE("TimelineModel: clamp_to_length pins indices into [0, len-1]",
     REQUIRE_FALSE(tl.clamp_to_length(entries));  // already in range
     REQUIRE(tl.current_frame() == 0);
 }
+
+// ---- Playback tests --------------------------------------------------
+//
+// tick_playback's clock-driven advance is wall-time dependent and
+// covered by the smoke test.  Here we exercise the gating conditions
+// (not playing, length <= 1) and the fps setter clamping, which are
+// the parts that can be asserted deterministically.
+
+TEST_CASE("TimelineModel: playback defaults to paused, 30 fps",
+          "[timeline_model][playback]") {
+    TimelineModel tl;
+    REQUIRE_FALSE(tl.playing());
+    REQUIRE(tl.playback_fps() == 30.0);
+}
+
+TEST_CASE("TimelineModel: set_playing toggles playing flag",
+          "[timeline_model][playback]") {
+    TimelineModel tl;
+    tl.set_playing(true);
+    REQUIRE(tl.playing());
+    tl.set_playing(false);
+    REQUIRE_FALSE(tl.playing());
+}
+
+TEST_CASE("TimelineModel: set_playback_fps clamps to [1, 120]",
+          "[timeline_model][playback]") {
+    TimelineModel tl;
+    tl.set_playback_fps(0.0);
+    REQUIRE(tl.playback_fps() == 1.0);
+    tl.set_playback_fps(-5.0);
+    REQUIRE(tl.playback_fps() == 1.0);
+    tl.set_playback_fps(999.0);
+    REQUIRE(tl.playback_fps() == 120.0);
+    tl.set_playback_fps(60.0);
+    REQUIRE(tl.playback_fps() == 60.0);
+}
+
+TEST_CASE("TimelineModel: tick_playback returns false when not playing",
+          "[timeline_model][playback]") {
+    std::vector<ImageEntry> entries;
+    entries.push_back(make_entry("clip", std::make_unique<StubSource>(10)));
+    TimelineModel tl;
+    // playing is false by default; tick must be a no-op.
+    REQUIRE_FALSE(tl.tick_playback(entries));
+    REQUIRE(tl.current_frame() == 0);
+}
+
+TEST_CASE("TimelineModel: tick_playback returns false when length <= 1",
+          "[timeline_model][playback]") {
+    std::vector<ImageEntry> entries;
+    entries.push_back(make_entry("still", std::make_unique<StubSource>(1)));
+    TimelineModel tl;
+    tl.set_playing(true);
+    REQUIRE_FALSE(tl.tick_playback(entries));
+    REQUIRE(tl.current_frame() == 0);
+}


### PR DESCRIPTION
TimelineModel gains playback state (playing flag, fps, steady-clock accumulator) and a tick_playback() method that advances the shared frame index by one when the clock deadline passes, looping back to 0 at the end.  Default is 30 fps, clamped to [1, 120].

App::frame() ticks playback at the top of every iteration so the UI reflects the advanced frame immediately, and wakes the idle tracker on each advance to keep the render loop spinning while playing.

Space toggles play/pause; Left/Right step one frame.  The timeline bar gets a Play/Pause button between the existing step buttons and an editable fps input next to the frame counter.

The clock-driven advance path is wall-time dependent and covered by the smoke test; the gating conditions (not playing, length <= 1) and fps clamping are covered by 5 new unit tests.